### PR TITLE
add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+node_modules


### PR DESCRIPTION
1. reduce docker build context (most is node_modules)
![image](https://user-images.githubusercontent.com/1747852/36941370-5bf82f34-1f94-11e8-8de5-d0e705c323b4.png)
![image](https://user-images.githubusercontent.com/1747852/36941371-638e48aa-1f94-11e8-9bbc-c34ef6624aa5.png)

2. node_modules should install within base image (now is node:9.5.0-alpine)
modules installed locally maybe cannot execute if the module need c++ build (paltform related)