### PR TITLE
Fix a typo in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Returns:
 }
 ```
 
-**Submit a links to be shortened**:
+**Submit a link to be shortened**:
 ```
 POST /api/url/submit
 ```


### PR DESCRIPTION
`links` 🢂 `link`