### PR TITLE
ZooKeeper integration support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6619,13 +6619,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6638,18 +6636,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6752,8 +6747,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6763,7 +6757,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6776,20 +6769,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -6806,7 +6796,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6879,8 +6868,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6890,7 +6878,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6996,7 +6983,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -9190,6 +9176,22 @@
       "integrity": "sha512-6VrvH7z6jqqNFY200kdB6HdzkgM96Oaj9v3dqGfgp6mF+cHmU4wyQKZ2/WPDRVoR0Jz9KqbamaBN0ZhdUaysUQ==",
       "requires": {
         "semver": "^5.3.0"
+      }
+    },
+    "node-zookeeper-client": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/node-zookeeper-client/-/node-zookeeper-client-0.2.3.tgz",
+      "integrity": "sha512-V4gVHxzQ42iwhkANpPryzfjmqi3Ql3xeO9E/px7W5Yi774WplU3YtqUpnvcL/eJit4UqcfuLOgZLkpf0BPhHmg==",
+      "requires": {
+        "async": "~0.2.7",
+        "underscore": "~1.4.4"
+      },
+      "dependencies": {
+        "async": {
+          "version": "0.2.10",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
+        }
       }
     },
     "nodemailer": {
@@ -11911,6 +11913,11 @@
           }
         }
       }
+    },
+    "underscore": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
+      "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ="
     },
     "unfetch": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "neo4j-driver": "^1.5.2",
     "next": "^7.0.2",
     "next-redux-wrapper": "^2.1.0",
+    "node-zookeeper-client": "^0.2.3",
     "nodemailer": "^4.4.1",
     "passport": "^0.4.0",
     "passport-jwt": "^4.0.0",

--- a/server/config.example.js
+++ b/server/config.example.js
@@ -13,6 +13,12 @@ module.exports = {
   REDIS_HOST: '127.0.0.1',
   REDIS_PORT: 6379,
 
+  /* Remote configuration server (optional) */
+  /* ZooKeeper Parameters */
+  // ZOOKEEPER_HOST: 'localhost',
+  // ZOOKEEPER_PORT: '2181',
+  // ZOOKEEPER_CONFIG_PATH: '/config/kutt',
+
   /* The daily limit for each user */
   USER_LIMIT_PER_DAY: 50,
 

--- a/server/remote-configuration/factory/remoteConfigurationFactory.js
+++ b/server/remote-configuration/factory/remoteConfigurationFactory.js
@@ -1,0 +1,58 @@
+const RemoteConfiguration = require('./remoteConfigurationInterface');
+const ZooKeeperConfiguration = require('./zooKeeperConfiguration');
+
+/**
+ * Factory Class for creating RemoteConfiguration Instances
+ */
+class RemoteConfigurationFactory {
+  /**
+   * This callback handles a new or updated configuration set
+   * @callback allConfigChangedCallback
+   * @param {object} config
+   */
+
+  /**
+   * This callback handles a deleted configuration property
+   * @callback configItemDeletedCallback
+   * @param {string} configKey
+   */
+
+  /**
+   * This callback handles a new or updated configuration property
+   * @callback configItemChangedCallback
+   * @param {string} configKey
+   * @param {*} configValue
+   */
+
+  /**
+   * GetConfiguration
+   * ============================================================
+   * Generates an implementation of RemoteConfiguration based on the passed configuration type.
+   * @param {string} [configurationType=NONE] the type of RemoteConfiguration to generate
+   * @param {configItemChangedCallback} [configItemChanged=()=>{}] callback to handle new or updated configuration properties
+   * @param {configItemDeletedCallback} [configItemDeleted=()=>{}] callback to handle deleted config configuration properties
+   * @param {allConfigChangedCallback} [allConfigChanged=()=>{}] callback to handle a new configuration set
+   * @returns {RemoteConfiguration} the generated implementation of RemoteConfiguration
+   */
+  static GetConfiguration(
+    configurationType = RemoteConfigurationFactory.NONE,
+    configItemChanged = () => {},
+    configItemDeleted = () => {},
+    allConfigChanged = () => {}
+  ) {
+    switch (configurationType) {
+      case RemoteConfigurationFactory.ZOOKEEPER:
+        return new ZooKeeperConfiguration(configItemChanged, configItemDeleted, allConfigChanged);
+      default:
+        return new RemoteConfiguration();
+    }
+  }
+}
+
+/**
+ * Static references to the different configuration types
+ */
+RemoteConfigurationFactory.NONE = 'NONE';
+RemoteConfigurationFactory.ZOOKEEPER = 'ZOOKEEPER';
+
+module.exports = RemoteConfigurationFactory;

--- a/server/remote-configuration/factory/remoteConfigurationInterface.js
+++ b/server/remote-configuration/factory/remoteConfigurationInterface.js
@@ -1,0 +1,81 @@
+/**
+ * Abstract Class for RemoteConfiguration Implementations
+ */
+module.exports = class RemoteConfiguration {
+  /**
+   * This callback handles a new or updated configuration set
+   * @callback allConfigChangedCallback
+   * @param {object} config
+   */
+
+  /**
+   * This callback handles a deleted configuration property
+   * @callback configItemDeletedCallback
+   * @param {string} configKey
+   */
+
+  /**
+   * This callback handles a new or updated configuration property
+   * @callback configItemChangedCallback
+   * @param {string} configKey
+   * @param {*} configValue
+   */
+
+  /**
+   * constructor
+   * ============================================================
+   * Instantiates the class RemoteConfiguration
+   * @param {configItemChangedCallback} [configItemChanged=()=>{}] callback to handle new or updated configuration properties
+   * @param {configItemDeletedCallback} [configItemDeleted=()=>{}] callback to handle deleted config configuration properties
+   * @param {allConfigChangedCallback} [allConfigChanged=()=>{}] callback to handle a new configuration set
+   */
+  constructor(
+    configItemChanged = () => {},
+    configItemDeleted = () => {},
+    allConfigChanged = () => {}
+  ) {
+    this.configItemChanged = configItemChanged;
+    this.configItemDeleted = configItemDeleted;
+    this.allConfigChanged = allConfigChanged;
+  }
+
+  /**
+   * connect
+   * ============================================================
+   * Placeholder method for connecting to remote configuration service,
+   * should be overridden by implementation
+   */
+  connect() {
+    this.connected = true;
+  }
+
+  /**
+   * setConfigItemChangedHandler
+   * ============================================================
+   * Sets a handler for new or updated configuration properties
+   * @param {configItemChangedCallback} configItemChanged callback to handle a new or updated configuration property
+   */
+  setConfigItemChangedHandler(configItemChanged) {
+    this.configItemChanged = configItemChanged;
+  }
+
+  /**
+   * setConfigItemDeletedHandler
+   * ============================================================
+   * Sets a handler for deleted configuration properties
+   * @param {configItemDeletedCallback} configItemDeleted callback to handle a deleted configuration property
+   */
+  setConfigItemDeletedHandler(configItemDeleted) {
+    this.configItemDeleted = configItemDeleted;
+  }
+
+  /**
+   * setConfigItemChangedHandler
+   * ============================================================
+   * Sets a handler for a new or updated configuration set
+   * @param {allConfigChangedCallback} allConfigChanged callback to handle a new or updated configuration set
+   */
+  setAllConfigChangedHandler(allConfigChanged) {
+    this.allConfigChanged = allConfigChanged;
+  }
+};

--- a/server/remote-configuration/factory/zooKeeperConfiguration.js
+++ b/server/remote-configuration/factory/zooKeeperConfiguration.js
@@ -1,0 +1,138 @@
+const zookeeper = require('node-zookeeper-client');
+const RemoteConfiguration = require('./remoteConfigurationInterface');
+
+/**
+ * Declare private methods as symbols so that they can not be accessed outside of the class
+ */
+
+const zkClient = Symbol('zkClient');
+const zooKeeperPath = Symbol('zooKeeperPath');
+
+/**
+ * checkPathExists - private
+ * ============================================================
+ * Checks to see if the configured path exists in the ZooKeeper node structure.
+ * If the path exists it lists the children so that their data can be retreived.
+ * Otherwise an error message is logged and the application stops watching ZooKeeper nodes.
+ */
+const checkPathExists = Symbol('checkPathExists');
+
+/**
+ * getChildNodes - private
+ * ============================================================
+ * Attempts to retreive all direct child nodes in the specified path in ZooKeeper.
+ */
+const getChildNodes = Symbol('getChildNodes');
+
+/**
+ * getNodeData - private
+ * ============================================================
+ * Attempts to retreive the value of a given node from ZooKeeper.
+ * @param {string} node The name of the node whose data to retreive
+ */
+const getNodeData = Symbol('getNodeData');
+
+/**
+ * Class for implementing ZooKeeper Remote Configuration
+ * @extends RemoteConfiguration
+ */
+module.exports = class ZooKeeperConfiguration extends RemoteConfiguration {
+  /**
+   * connect
+   * ============================================================
+   * Starts the ZooKeeper client and listens for changes to the configuration path.
+   * @param {string} connectionString host and port of the ZooKeeper server.  (ex. 'localhost:2181')
+   * @param {string} [path=/config/kutt] the path of the configuration nodes in ZooKeeper
+   */
+  connect(connectionString, path = '/config/kutt') {
+    this[zooKeeperPath] = path;
+    this[zkClient] = zookeeper.createClient(connectionString);
+
+    this[zkClient].once('connected', () => {
+      console.log('Connected to ZooKeeper.'); // eslint-disable-line no-console
+      this[checkPathExists]();
+    });
+
+    console.log('Trying to connect to ZooKeeper.'); // eslint-disable-line no-console
+    this[zkClient].connect();
+  }
+
+  /**
+   * checkPathExists - private
+   * ============================================================
+   * Checks to see if the configured path exists in the ZooKeeper node structure.
+   * If the path exists it lists the children so that their data can be retreived.
+   * Otherwise an error message is logged and the application stops watching ZooKeeper nodes.
+   */
+  [checkPathExists]() {
+    this[zkClient].exists(this[zooKeeperPath], (error, stat) => {
+      if (error) {
+        console.log('Failed to check for path due to to: %s.', error); // eslint-disable-line no-console
+        return;
+      }
+
+      if (stat) {
+        this[getChildNodes]();
+      } else {
+        console.log('No node exists at path: %s.', this[zooKeeperPath]); // eslint-disable-line no-console
+        console.log('Disconnecting from ZooKeeper server'); // eslint-disable-line no-console
+        this[zkClient].close();
+      }
+    });
+  }
+
+  /**
+   * getChildNodes - private
+   * ============================================================
+   * Attempts to retreive all direct child nodes in the specified path in ZooKeeper.
+   */
+  [getChildNodes]() {
+    this[zkClient].getChildren(
+      this[zooKeeperPath],
+      event => {
+        console.log('Got watcher event: %s', event); // eslint-disable-line no-console
+        this[getChildNodes]();
+      },
+      (error, children) => {
+        if (error) {
+          console.log('Failed to list children of %s due to: %s.', this[zooKeeperPath], error); // eslint-disable-line no-console
+          return;
+        }
+
+        console.log('Children of %s are: %j.', this[zooKeeperPath], children); // eslint-disable-line no-console
+        children.forEach(child => {
+          this[getNodeData](child);
+        });
+      }
+    );
+  }
+
+  /**
+   * getNodeData
+   * ============================================================
+   * Attempts to retreive the value of a given node from ZooKeeper.
+   * @param {string} node The name of the node whose data to retreive
+   */
+  [getNodeData](node) {
+    this[zkClient].getData(
+      `${this[zooKeeperPath]}/${node}`,
+      event => {
+        console.log('Got event: %s.', event); // eslint-disable-line no-console
+        if (event.name === 'NODE_DELETED') {
+          console.log('Deleting config property associated with deleted node.'); // eslint-disable-line no-console
+          this.configItemDeleted(node);
+        } else {
+          this[getNodeData](node);
+        }
+      },
+      (error, data) => {
+        if (error) {
+          console.log(error.stack); // eslint-disable-line no-console
+          return;
+        }
+        console.log('Got data: %s', data.toString('utf8')); // eslint-disable-line no-console
+        this.configItemChanged(node, data.toString('utf8'));
+      }
+    );
+  }
+};

--- a/server/remote-configuration/remoteConfigurationLoader.js
+++ b/server/remote-configuration/remoteConfigurationLoader.js
@@ -1,0 +1,158 @@
+const config = require('../config');
+const RemoteConfigurationFactory = require('./factory/remoteConfigurationFactory');
+
+/**
+ * Remote Configuration Loader
+ * ============================================================
+ * Determines, based on ./server/config.js, whether to use a remote configuration server.
+ * If remote configuration is enabled, the loadConfiguration method will initate it.
+ *
+ * The only configuration that will be affected will be server configuration at './server/config.js'
+ * and not all values are subject to remote configuration.  For example PORT and ZOOKEEPER settings
+ * are utilized before this method is called, and they are not called again.
+ */
+
+/**
+ * deleteConfigProperty
+ * ============================================================
+ * Delete an item from the configuration values
+ * @param {string} prop The name of the configuration property to delete
+ */
+const deleteConfigProperty = prop => {
+  delete config[prop];
+};
+
+/**
+ * setConfigProperty
+ * ============================================================
+ * Update the application config with a new value, assuming the new value can be parsed
+ * @param {string} prop The name of the configuration property to update
+ * @param {*} val The name of the configuration property to update
+ */
+const setConfigProperty = (prop, val) => {
+  if (val === undefined) {
+    deleteConfigProperty(prop);
+    return;
+  }
+
+  config[prop] = val;
+};
+
+/**
+ * updateEntireConfig
+ * ============================================================
+ * Update the application config with a new set of values
+ * @param {object} newConfig the new config object to read values from
+ */
+const updateEntireConfig = newConfig => {
+  Object.keys(newConfig).forEach(prop => {
+    setConfigProperty(prop, newConfig[prop]);
+  });
+};
+
+/**
+ * parseConfigValue
+ * ============================================================
+ * Attempt to parse a string value into it's appropriate type for configuration
+ * @param {string} value The value to parse
+ * @param {string} [type=undefined] The expected type of the returned value
+ * @return {*} the value converted to it's proper type, or undefined
+ */
+const parseConfigValue = (value, type = 'undefined') => {
+  if (value === null || value === '') {
+    return undefined;
+  }
+
+  switch (type) {
+    case 'string':
+      return value;
+    case 'number':
+      return Number(value);
+    case 'boolean':
+      return value.toLowerCase().indexOf('true') > -1;
+    case 'object':
+      try {
+        return JSON.parse(value);
+      } catch (error) {
+        console.log(`Error parsing object from value : ${value}`); // eslint-disable-line no-console
+      }
+      break;
+    default:
+      /* Undetermined type, attempt to parse and default to string */
+      try {
+        return JSON.parse(value);
+      } catch (error) {
+        console.log(`Can't parse value from : ${value}`); // eslint-disable-line no-console
+        console.log('Defaulting to type string'); // eslint-disable-line no-console
+        return value;
+      }
+  }
+
+  return undefined;
+};
+
+/**
+ * getRemoteConfigurationType
+ * ============================================================
+ * Determines and returns the appropriate RemoteConfiguration type
+ * @return {string} RemoteConfiguration Type
+ */
+const getRemoteConfigurationType = () => {
+  if (config.ZOOKEEPER_HOST && config.ZOOKEEPER_PORT && config.ZOOKEEPER_CONFIG_PATH)
+    return RemoteConfigurationFactory.ZOOKEEPER;
+
+  return RemoteConfigurationFactory.NONE;
+};
+
+/**
+ * getConfigurationCallbacks
+ * ============================================================
+ * Generate the appropriate callbacks based on a passed configurationType
+ * @param {string} configurationType the type of RemoteConfiguration to generate callbacks for
+ * @return {Array} the list of callbacks to send to RemoteConfigurationFactory.GetConfiguration
+ */
+const getConfigurationCallbacks = configurationType => {
+  switch (configurationType) {
+    case RemoteConfigurationFactory.ZOOKEEPER:
+      return [
+        /* ZooKeeper returns all node values as strings, so we need to implement the parser */
+        (prop, val) => {
+          setConfigProperty(prop, parseConfigValue(val, typeof config[prop]));
+        },
+        deleteConfigProperty,
+        updateEntireConfig,
+      ];
+    default:
+      return [];
+  }
+};
+
+/**
+ * getConnectionArguments
+ * ============================================================
+ * Generate the appropriate connection arguments based on a passed configurationType
+ * @param {string} configurationType the type of RemoteConfiguration to generate arguments for
+ * @return {Array} the list of arguments to send to the RemoteConfiguration implementations connect method
+ */
+const getConnectionArguments = configurationType => {
+  switch (configurationType) {
+    case RemoteConfigurationFactory.ZOOKEEPER:
+      return [`${config.ZOOKEEPER_HOST}:${config.ZOOKEEPER_PORT}`, config.ZOOKEEPER_CONFIG_PATH];
+    default:
+      return [];
+  }
+};
+
+/**
+ * loadConfiguration
+ * ============================================================
+ * Start listening for remote configuration, if there is any
+ */
+exports.loadConfiguration = () => {
+  const configurationType = getRemoteConfigurationType();
+
+  RemoteConfigurationFactory.GetConfiguration(
+    configurationType,
+    ...getConfigurationCallbacks(configurationType)
+  ).connect(...getConnectionArguments(configurationType));
+};

--- a/server/server.js
+++ b/server/server.js
@@ -18,6 +18,7 @@ const {
 const auth = require('./controllers/authController');
 const url = require('./controllers/urlController');
 const config = require('./config');
+const remoteConfigurationLoader = require('./remote-configuration/remoteConfigurationLoader');
 
 require('./passport');
 
@@ -43,6 +44,9 @@ const handle = app.getRequestHandler();
 
 app.prepare().then(() => {
   const server = express();
+
+  /* Begin listening for remote configuration changes */
+  remoteConfigurationLoader.loadConfiguration();
 
   server.set('trust proxy', true);
   server.use(helmet());


### PR DESCRIPTION
Allow changing configuration remotely without bringing down the service via ZooKeeper ZNodes.
Implements a factory pattern such that any other remote configuration solution might be implemented as well.

This change will have no affect if ZooKeeper is not configured.