### PR TITLE
Update url for kutt-bash

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ You can use Kutt as your default URL shortener in [ShareX](https://getsharex.com
 | Python    | [kutt-cli](https://github.com/univa64/kutt-cli)            | Command-line client for Kutt written in Python    |
 | Ruby      | [kutt.rb](https://github.com/univa64/kutt.rb)              | Kutt library written in Ruby                      |
 | Node.js   | [node-kutt](https://github.com/ardalanamini/node-kutt)     | Node.js client for Kutt.it url shortener          |
-| Bash      | [kutt-bash](https://github.com/caltlgin/kutt-bash)         | Simple command line program for Kutt              |
+| Bash      | [kutt-bash](https://git.nixnet.xyz/caltlgin/kutt-bash)     | Simple command line program for Kutt              |
 
 ## Contributing
 Pull requests are welcome. You'll probably find lots of improvements to be made.


### PR DESCRIPTION
URL for kutt-bash changed from https://github.com/caltlgin/kutt-bash to https://git.nixnet.xyz/caltlgin/kutt-bash as the maintainer has moved the code to a Gitea instance.