### PR TITLE
report hostname fix

### DIFF
--- a/server/controllers/linkController.ts
+++ b/server/controllers/linkController.ts
@@ -340,7 +340,8 @@ export const reportLink: Handler = async (req, res) => {
     return res.status(400).json({ error: "No URL has been provided." });
   }
 
-  const { hostname } = URL.parse(req.body.link);
+  var { hostname } = URL.parse(req.body.link);
+  if (!hostname || Number(hostname)) hostname = req.body.link.split("/")[0];
   if (hostname !== process.env.DEFAULT_DOMAIN) {
     return res.status(400).json({
       error: `You can only report a ${process.env.DEFAULT_DOMAIN} link`


### PR DESCRIPTION
By default on report page example url looks like `kutt.it/example`, but in this case `hostname` variable is parsed as `null` and API will raise an error. Specifying link with schema as `https://kutt.it/example` will work but does not match specified example.
This pull request should fix the issue.