### PR TITLE
Change links and text when used with custom domain

### DIFF
--- a/client/components/Header/HeaderLogo.js
+++ b/client/components/Header/HeaderLogo.js
@@ -41,7 +41,7 @@ const HeaderLogo = props => {
     <LogoImage>
       <a href="/" title="Homepage" onClick={goTo}>
         <img src="/images/logo.svg" alt="" />
-        Kutt.it
+        { process.env.DEFAULT_DOMAIN || "Kutt.it" }
       </a>
     </LogoImage>
   );

--- a/client/components/Settings/SettingsDomain.js
+++ b/client/components/Settings/SettingsDomain.js
@@ -98,7 +98,7 @@ const SettingsDomain = ({
     <h3>Custom domain</h3>
     <p>
       You can set a custom domain for your short URLs, so instead of <b>kutt.it/shorturl</b> you can
-      have <b>example.com/shorturl.</b>
+      have <b>{ process.env.DEFAULT_DOMAIN || "example.com" } /shorturl.</b>
     </p>
     <p>
       Point your domain A record to <b>192.64.116.170</b> then add the domain via form below:

--- a/client/pages/_document.js
+++ b/client/pages/_document.js
@@ -26,7 +26,7 @@ class AppDocument extends Document {
           <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
           <meta
             name="description"
-            content="Kutt.it is a free and open source URL shortener with custom domains and stats."
+            content={ (process.env.DEFAULT_DOMAIN || "kutt.it") + "is a free and open source URL shortener with custom domains and stats." }
           />
           <link
             href="https://fonts.googleapis.com/css?family=Nunito:300,400,700"
@@ -41,15 +41,27 @@ class AppDocument extends Document {
           <meta name="theme-color" content="#f3f3f3" />
 
           <meta property="fb:app_id" content="123456789" />
-          <meta property="og:url" content="https://kutt.it" />
+          <meta property="og:url" content={
+            ((process.env.CUSTOM_DOMAIN_USE_HTTPS && process.env.CUSTOM_DOMAIN_USE_HTTPS === "false") ? "http" : "https")
+              + "://" + (process.env.DEFAULT_DOMAIN || "kutt.it")
+          } />
           <meta property="og:type" content="website" />
-          <meta property="og:title" content="Kutt.it" />
-          <meta property="og:image" content="https://kutt.it/images/card.png" />
+          <meta property="og:title" content={ (process.env.DEFAULT_DOMAIN || "kutt.it") } />
+          <meta property="og:image" content={
+            ((process.env.CUSTOM_DOMAIN_USE_HTTPS && process.env.CUSTOM_DOMAIN_USE_HTTPS === "false") ? "http" : "https")
+              + "://" + (process.env.DEFAULT_DOMAIN || "kutt.it") + "/images/card.png"
+          } />
           <meta property="og:description" content="Free & Open Source Modern URL Shortener" />
-          <meta name="twitter:url" content="https://kutt.it" />
-          <meta name="twitter:title" content="Kutt.it" />
+          <meta name="twitter:url" content={
+            ((process.env.CUSTOM_DOMAIN_USE_HTTPS && process.env.CUSTOM_DOMAIN_USE_HTTPS === "false") ? "http" : "https")
+              + "://" + (process.env.DEFAULT_DOMAIN || "kutt.it")
+          } />
+          <meta name="twitter:title" content={ (process.env.DEFAULT_DOMAIN || "kutt.it")} />
           <meta name="twitter:description" content="Free & Open Source Modern URL Shortener" />
-          <meta name="twitter:image" content="https://kutt.it/images/card.png" />
+          <meta name="twitter:image" content={
+            ((process.env.CUSTOM_DOMAIN_USE_HTTPS && process.env.CUSTOM_DOMAIN_USE_HTTPS === "false") ? "http" : "https")
+              + "://" + (process.env.DEFAULT_DOMAIN || "kutt.it") + "/images/card.png" 
+          } />
 
           {this.props.styleTags}
 

--- a/client/pages/report.js
+++ b/client/pages/report.js
@@ -104,7 +104,10 @@ class ReportPage extends Component {
           <Form onSubmit={this.onSubmit}>
             <TextInput
               type="text"
-              placeholder="kutt.it/example"
+              placeholder= {
+                ((process.env.CUSTOM_DOMAIN_USE_HTTPS && process.env.CUSTOM_DOMAIN_USE_HTTPS === "false") ? "http" : "https")
+                  + "://" + (process.env.DEFAULT_DOMAIN || "kutt.it") + "/example"
+              }
               value={url}
               onChange={this.onChange}
               height={44}

--- a/client/pages/terms.js
+++ b/client/pages/terms.js
@@ -14,37 +14,43 @@ const Wrapper = styled.div`
 const TermsPage = () => (
   <BodyWrapper>
     <Wrapper>
-      <h3>Kutt Terms of Service</h3>
+      <h3>{ process.env.DEFAULT_DOMAIN || "Kutt" } Terms of Service</h3>
       <p>
-        By accessing the website at <a href="https://kutt.it">https://kutt.it</a>, you are agreeing
+        By accessing the website at <a href={
+          ((process.env.CUSTOM_DOMAIN_USE_HTTPS && process.env.CUSTOM_DOMAIN_USE_HTTPS === "false") ? "http" : "https")
+              + "://" + (process.env.DEFAULT_DOMAIN || "kutt.it")
+        }>{
+          ((process.env.CUSTOM_DOMAIN_USE_HTTPS && process.env.CUSTOM_DOMAIN_USE_HTTPS === "false") ? "http" : "https")
+              + "://" + (process.env.DEFAULT_DOMAIN || "kutt.it")
+        }</a>, you are agreeing
         to be bound by these terms of service, all applicable laws and regulations, and agree that
         you are responsible for compliance with any applicable local laws. If you do not agree with
         any of these terms, you are prohibited from using or accessing this site. The materials
         contained in this website are protected by applicable copyright and trademark law.
       </p>
       <p>
-        In no event shall Kutt or its suppliers be liable for any damages (including, without
+        In no event shall { process.env.DEFAULT_DOMAIN || "Kutt" } or its suppliers be liable for any damages (including, without
         limitation, damages for loss of data or profit, or due to business interruption) arising out
-        of the use or inability to use the materials on {"Kutt's"} website, even if Kutt or a Kutt
+        of the use or inability to use the materials on { (process.env.DEFAULT_DOMAIN || "Kutt") +"'s" } website, even if { process.env.DEFAULT_DOMAIN || "Kutt" } or a { process.env.DEFAULT_DOMAIN || "Kutt" }
         authorized representative has been notified orally or in writing of the possibility of such
         damage. Because some jurisdictions do not allow limitations on implied warranties, or
         limitations of liability for consequential or incidental damages, these limitations may not
         apply to you.
       </p>
       <p>
-        The materials appearing on Kutt website could include technical, typographical, or
-        photographic errors. Kutt does not warrant that any of the materials on its website are
-        accurate, complete or current. Kutt may make changes to the materials contained on its
-        website at any time without notice. However Kutt does not make any commitment to update the
+        The materials appearing on { process.env.DEFAULT_DOMAIN || "Kutt" } website could include technical, typographical, or
+        photographic errors. { process.env.DEFAULT_DOMAIN || "Kutt" } does not warrant that any of the materials on its website are
+        accurate, complete or current. { process.env.DEFAULT_DOMAIN || "Kutt" } may make changes to the materials contained on its
+        website at any time without notice. However { process.env.DEFAULT_DOMAIN || "Kutt" } does not make any commitment to update the
         materials.
       </p>
       <p>
-        Kutt has not reviewed all of the sites linked to its website and is not responsible for the
+        { process.env.DEFAULT_DOMAIN || "Kutt" } has not reviewed all of the sites linked to its website and is not responsible for the
         contents of any such linked site. The inclusion of any link does not imply endorsement by
         Kutt of the site. Use of any such linked website is at the {"user's"} own risk.
       </p>
       <p>
-        Kutt may revise these terms of service for its website at any time without notice. By using
+        { process.env.DEFAULT_DOMAIN || "Kutt" } may revise these terms of service for its website at any time without notice. By using
         this website you are agreeing to be bound by the then current version of these terms of
         service.
       </p>

--- a/server/mail/template-reset.html
+++ b/server/mail/template-reset.html
@@ -311,7 +311,7 @@
                             <span style="color: rgb(0, 0, 0); font-size: 14px; line-height: 28px;">
                               <strong>
                                 <span style="line-height: 56px; font-size: 28px;">
-                                  <span style="font-size: 24px; line-height: 48px;">Kutt</span>.</span>
+                                  <span style="font-size: 24px; line-height: 48px;">{{domain}}</span>.</span>
                               </strong>
                               <span style="line-height: 56px; font-size: 28px;"></span>
                             </span>

--- a/server/mail/template-verify.html
+++ b/server/mail/template-verify.html
@@ -311,7 +311,7 @@
                             <span style="color: rgb(0, 0, 0); font-size: 14px; line-height: 28px;">
                               <strong>
                                 <span style="line-height: 56px; font-size: 28px;">
-                                  <span style="font-size: 24px; line-height: 48px;">Kutt</span>.</span>
+                                  <span style="font-size: 24px; line-height: 48px;">{{domain}}</span>.</span>
                               </strong>
                               <span style="line-height: 56px; font-size: 28px;"></span>
                             </span>
@@ -347,7 +347,7 @@
                       <!--[if mso]><table width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="padding-right: 30px; padding-left: 30px; padding-top: 30px; padding-bottom: 30px;"><![endif]-->
                       <div style="color:#555555;line-height:180%;font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif; padding-right: 30px; padding-left: 30px; padding-top: 30px; padding-bottom: 30px;">
                         <div style="font-size:12px;line-height:22px;color:#555555;font-family:Arial, 'Helvetica Neue', Helvetica, sans-serif;text-align:left;">
-                          <p style="margin: 0;font-size: 14px;line-height: 25px">Thanks for creating an account on Kutt.it.
+                          <p style="margin: 0;font-size: 14px;line-height: 25px">Thanks for creating an account on {{domain}}.
                             <br>
                           </p>
                           <p style="margin: 0;font-size: 14px;line-height: 25px">Please verify your email address using the link below.</p>

--- a/server/mail/text.ts
+++ b/server/mail/text.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-len */
-export const verifyMailText = `Thanks for creating an account on Kutt.it.
+export const verifyMailText = `Thanks for creating an account on {{domain}}.
 
 Please verify your email address using the link below.
 


### PR DESCRIPTION
Not sure, if it was intended, but when custom domain name is used, some links and pages still refer to kutt.it and in some links protocol was hard-coded to `https`.