### PR TITLE
fix: use MAIL_FROM (preferably) for send email

### DIFF
--- a/server/controllers/authController.ts
+++ b/server/controllers/authController.ts
@@ -240,7 +240,7 @@ export const requestUserPasswordReset: Handler = async (req, res) => {
   }
 
   const mail = await transporter.sendMail({
-    from: process.env.MAIL_USER,
+    from: process.env.MAIL_FROM || process.env.MAIL_USER,
     to: user.email,
     subject: "Reset your password",
     text: resetMailText

--- a/server/controllers/linkController.ts
+++ b/server/controllers/linkController.ts
@@ -348,7 +348,7 @@ export const reportLink: Handler = async (req, res) => {
   }
 
   const mail = await transporter.sendMail({
-    from: process.env.MAIL_USER,
+    from: process.env.MAIL_FROM || process.env.MAIL_USER,
     to: process.env.REPORT_MAIL,
     subject: "[REPORT]",
     text: req.body.link,


### PR DESCRIPTION
Changing the preference for using the **MAIL_FROM** environment variable when sending e-mails.

Some e-mail sending services like Amazon SES and Sendgrid do not use an e-mail in the user parameter for authentication (in the case of Sendgrid it is a constant **apikey**).