### PR TITLE
Pass env.DB_SSL to Knex so that migrations succeed with SSL

### DIFF
--- a/knexfile.ts
+++ b/knexfile.ts
@@ -8,7 +8,8 @@ module.exports = {
       database: env.DB_NAME,
       user: env.DB_USER,
       port: env.DB_PORT,
-      password: env.DB_PASSWORD
+      password: env.DB_PASSWORD,
+      ssl: env.DB_SSL,
     },
     migrations: {
       tableName: "knex_migrations",


### PR DESCRIPTION
I ran into issues running Kutt with `DB_SSL` set to `true`, it turns out this wasn't being passed to Knex for migrations. This PR passes the value to Knex while running migrations 🎉 

Thanks for making Kutt, it's a joy to use! ✌️ 