### PR TITLE
Allow multiple custom domains

### DIFF
--- a/client/components/Settings/SettingsDomain.tsx
+++ b/client/components/Settings/SettingsDomain.tsx
@@ -78,7 +78,7 @@ const SettingsDomain: FC = () => {
         Point your domain A record to <b>192.64.116.170</b> then add the domain
         via form below:
       </Text>
-      {domains.length ? (
+      {domains.length > 0 && (
         <Table my={3} scrollWidth="550px">
           <thead>
             <tr>
@@ -115,7 +115,7 @@ const SettingsDomain: FC = () => {
             ))}
           </tbody>
         </Table>
-      ) : (
+      )}
         <Col
           alignItems="flex-start"
           onSubmit={onSubmit}
@@ -164,7 +164,6 @@ const SettingsDomain: FC = () => {
             {loading ? "Setting..." : "Set domain"}
           </Button>
         </Col>
-      )}
       <Text color={message.color}>{message.text}</Text>
       <Modal id="delete-custom-domain" show={modal} closeHandler={closeModal}>
         <H2 mb={24} textAlign="center" bold>

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev": "npm run migrate && nodemon server/server.ts",
     "build": "next build client/ && rimraf production-server && tsc --project tsconfig.json && copyfiles -f \"server/mail/*.html\" production-server/mail",
     "start": "npm run migrate && NODE_ENV=production node production-server/server.js",
-    "migrate": "knex migrate:up --env production",
+    "migrate": "knex migrate:latest --env production",
     "lint": "eslint server/ --ext .js,.ts --fix",
     "lint:nofix": "eslint server/ --ext .js,.ts",
     "docs:build": "cd docs/api && tsc generate.ts --resolveJsonModule && node generate && cd ../.."

--- a/server/handlers/domains.ts
+++ b/server/handlers/domains.ts
@@ -1,5 +1,6 @@
 import { Handler } from "express";
 import query from "../queries";
+import * as redis from "../redis";
 import { CustomError, sanitize } from "../utils";
 
 export const add: Handler = async (req, res) => {
@@ -22,6 +23,8 @@ export const remove: Handler = async (req, res) => {
     },
     { user_id: null }
   );
+
+  redis.remove.domain(domain);
 
   if (!domain) {
     throw new CustomError("Could not delete the domain.", 500);

--- a/server/handlers/validators.ts
+++ b/server/handlers/validators.ts
@@ -155,11 +155,6 @@ export const addDomain = [
     .custom(value => urlRegex({ exact: true, strict: false }).test(value))
     .custom(value => value !== env.DEFAULT_DOMAIN)
     .withMessage("You can't use the default domain.")
-    .custom(async (value, { req }) => {
-      const domains = await query.domain.get({ user_id: req.user.id });
-      if (domains.length !== 0) return Promise.reject();
-    })
-    .withMessage("You already own a domain. Contact support if you need more.")
     .custom(async value => {
       const domain = await query.domain.find({ address: value });
       if (domain?.user_id || domain?.banned) return Promise.reject();

--- a/server/migrations/20200510140704_domains.ts
+++ b/server/migrations/20200510140704_domains.ts
@@ -1,0 +1,26 @@
+import * as Knex from "knex";
+import * as models from "../models";
+
+export async function up(knex: Knex): Promise<any> {
+  await models.createUserTable(knex);
+  await models.createIPTable(knex);
+  await models.createDomainTable(knex);
+  await models.createHostTable(knex);
+  await models.createLinkTable(knex);
+  await models.createVisitTable(knex);
+
+  await Promise.all([
+    knex.raw(`
+      ALTER TABLE domains
+      DROP CONSTRAINT IF EXISTS domains_user_id_unique
+    `),
+    knex.raw(`
+      ALTER TABLE domains
+      ADD COLUMN IF NOT EXISTS uuid UUID DEFAULT uuid_generate_v4()
+    `)
+  ]);
+}
+
+export async function down(knex: Knex): Promise<any> {
+  // do nothing
+}

--- a/server/models/domain.ts
+++ b/server/models/domain.ts
@@ -23,8 +23,11 @@ export async function createDomainTable(knex: Knex) {
         .integer("user_id")
         .references("id")
         .inTable("users")
-        .onDelete("SET NULL")
-        .unique();
+        .onDelete("SET NULL");
+      table
+        .uuid("uuid")
+        .notNullable()
+        .defaultTo(knex.raw("uuid_generate_v4()"));
       table.timestamps(false, true);
     });
   }


### PR DESCRIPTION
Closes #230.

### Changes
* Add migration to remove unique constraint on user_id in domains table
* Run latest migrations on start, rather than next migration
* Allow client to show multiple domains
* Remove domains from Redis when they are deleted

### Fixes
* Add migration to add `uuid` field to domains table. It seems like this once existed but was at some point removed? I ran into issues deleting domains without the `uuid` field.

<details>
<summary>View demo GIF</summary>

![Screen Capture on 2020-05-14 at 17-19-25](https://user-images.githubusercontent.com/1646536/81934678-b0fb1e80-9632-11ea-8e21-55a37ead5f45.gif)

</details>

Let me know if there's anything I can change to help this get merged ✌️ 