### PR TITLE
Add Oxford comma to features section

### DIFF
--- a/client/components/Features.tsx
+++ b/client/components/Features.tsx
@@ -32,7 +32,7 @@ const Features = () => (
         Use custom domains for your links. Add or remove them for free.
       </FeaturesItem>
       <FeaturesItem title="API" icon="zap">
-        Use the provided API to create, delete and get URLs from anywhere.
+        Use the provided API to create, delete, and get URLs from anywhere.
       </FeaturesItem>
       <FeaturesItem title="Free &amp; open source" icon="heart">
         Completely open source and free. You can host it on your own server.


### PR DESCRIPTION
*Very* minor and inconsequential change that adds an [Oxford comma](https://www.grammarly.com/blog/what-is-the-oxford-comma-and-why-do-people-care-so-much-about-it/) to the features section. 

Not at all an important change, but when I first read [it](https://github.com/thedevs-network/kutt/blob/314ba0c833ddafb98bbd31fd78c57a1a0989f607/client/components/Features.tsx#L35), I was confused for a second, so perhaps this small addition could simplify things for another person. 

Addresses #350.