### PR TITLE
Sanitize docker-compose

### DIFF
--- a/.docker.env
+++ b/.docker.env
@@ -1,0 +1,84 @@
+# App port to run on
+PORT=3000
+
+# The domain that this website is on
+SITE_NAME=Kutt
+
+# The domain that this website is on
+DEFAULT_DOMAIN=localhost:3000
+
+# Generated link length
+LINK_LENGTH=6
+
+# Postgres database credential details
+DB_HOST=postgres
+DB_PORT=5432
+DB_NAME=postgres
+DB_USER=
+DB_PASSWORD=
+DB_SSL=false
+
+# ONLY NEEDED FOR MIGRATION !!1!
+# Neo4j database credential details
+NEO4J_DB_URI=bolt://localhost
+NEO4J_DB_USERNAME=neo4j
+NEO4J_DB_PASSWORD=BjEphmupAf1D5pDD
+
+# Redis host and port
+REDIS_HOST=redis
+REDIS_PORT=6379
+REDIS_PASSWORD=
+
+# The daily limit for each user
+USER_LIMIT_PER_DAY=50
+
+# Create a cooldown for non-logged in users in minutes
+# Set 0 to disable
+NON_USER_COOLDOWN=0
+
+# Max number of visits for each link to have detailed stats
+DEFAULT_MAX_STATS_PER_LINK=5000
+
+# Use HTTPS for links with custom domain
+CUSTOM_DOMAIN_USE_HTTPS=false
+
+# A passphrase to encrypt JWT. Use a long and secure key.
+JWT_SECRET=securekey
+
+# Admin emails so they can access admin actions on settings page
+# Comma seperated
+ADMIN_EMAILS=
+
+# Invisible reCaptcha secret key
+# Create one in https://www.google.com/recaptcha/intro/
+RECAPTCHA_SITE_KEY=
+RECAPTCHA_SECRET_KEY=
+
+# Google Cloud API to prevent from users from submitting malware URLs.
+# Get it from https://developers.google.com/safe-browsing/v4/get-started
+GOOGLE_SAFE_BROWSING_KEY=
+
+# Google Analytics tracking ID for universal analytics.
+# Example: UA-XXXX-XX
+GOOGLE_ANALYTICS=
+GOOGLE_ANALYTICS_UNIVERSAL=
+
+# Google Analytics tracking ID for universal analytics
+# This one is used for links
+# GOOGLE_ANALYRICS_UNIVERSAL=
+
+# Your email host details to use to send verification emails.
+# More info on http://nodemailer.com/
+# Mail from example "Kutt <support@kutt.it>". Leave empty to use MAIL_USER
+MAIL_HOST=
+MAIL_PORT=
+MAIL_SECURE=true
+MAIL_USER=
+MAIL_FROM=
+MAIL_PASSWORD=
+
+# The email address that will receive submitted reports.
+REPORT_EMAIL=
+
+# Support email to show on the app
+CONTACT_EMAIL=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,6 @@ version: "3"
 services:
   kutt:
     image: kutt/kutt
-    container_name: kutt
     depends_on:
       - postgres
       - redis
@@ -18,27 +17,21 @@ services:
       DB_USER: user
       DB_PASSWORD: pass
       REDIS_HOST: redis
-    networks:
-      - kutt-network
 
   redis:
-    image: redis:alpine
-    container_name: redis
-    networks:
-      - kutt-network
+    image: redis:6.0-alpine
+    volumes:
+      - redis_data:/data
 
   postgres:
     image: postgres:12-alpine
-    container_name: postgres
     environment:
       POSTGRES_USER: user
       POSTGRES_PASSWORD: pass
       POSTGRES_DB: kutt
-    ports:
-      - "54323:5432"
-    networks:
-      - kutt-network
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
 
-networks:
-  kutt-network:
-    driver: "bridge"
+volumes:
+  redis_data:
+  postgres_data:


### PR DESCRIPTION
- remove the container names since this is not mandatory and the feature is not used.
- remove the network since all containers can communicate with each other when using docker-compose.
- add persistence to the databases to avoid the loss of data.
- add `.env`-file for docker