### PR TITLE
Fix small typos

### DIFF
--- a/.docker.env
+++ b/.docker.env
@@ -1,7 +1,7 @@
 # App port to run on
 PORT=3000
 
-# The domain that this website is on
+# The name of the site where Kutt is hosted
 SITE_NAME=Kutt
 
 # The domain that this website is on
@@ -71,7 +71,7 @@ GOOGLE_ANALYTICS_UNIVERSAL=
 
 # Google Analytics tracking ID for universal analytics
 # This one is used for links
-# GOOGLE_ANALYRICS_UNIVERSAL=
+# GOOGLE_ANALYTICS_UNIVERSAL=
 
 # Your email host details to use to send verification emails.
 # More info on http://nodemailer.com/

--- a/.example.env
+++ b/.example.env
@@ -1,7 +1,7 @@
 # App port to run on
 PORT=3000
 
-# The domain that this website is on
+# The name of the site where Kutt is hosted
 SITE_NAME=Kutt
 
 # The domain that this website is on
@@ -72,7 +72,7 @@ GOOGLE_ANALYTICS_UNIVERSAL=
 
 # Google Analytics tracking ID for universal analytics
 # This one is used for links
-# GOOGLE_ANALYRICS_UNIVERSAL=
+# GOOGLE_ANALYTICS_UNIVERSAL=
 
 # Your email host details to use to send verification emails.
 # More info on http://nodemailer.com/

--- a/.template.env
+++ b/.template.env
@@ -44,7 +44,7 @@ GOOGLE_ANALYTICS={{GOOGLE_ANALYTICS}}
 
 # Google Analytics tracking ID for universal analytics
 # This one is used for links
-GOOGLE_ANALYRICS_UNIVERSAL={{GOOGLE_ANALYRICS_UNIVERSAL}}
+GOOGLE_ANALYTICS_UNIVERSAL={{GOOGLE_ANALYTICS_UNIVERSAL}}
 
 # Your email host details to use to send verification emails.
 # More info on http://nodemailer.com/


### PR DESCRIPTION
So, I was configuring kutt.it for our usage ([kodul.ar](https://kodul.ar)), and it works really great! The UI is so smooth 👏
I just found a few typos in the env files.

BTW, I was not able to get the SITE_NAME config working. We currently have it to `SITE_NAME=Kodul.ar`, but title appears as ` | Modern Open Source URL shortener.`. As you can see here, it doesn't show the site name (and well, it shows to point to the kutt.it IP rather than the instance one).
![image](https://user-images.githubusercontent.com/19251112/93665985-eb5e4780-fa7a-11ea-9100-80b062fcac7b.png)
