### PR TITLE
Reuse Fix for URL Encoded Input and Cache Fix for v1 API

### DIFF
--- a/server/__v1/controllers/linkController.ts
+++ b/server/__v1/controllers/linkController.ts
@@ -44,17 +44,25 @@ const generateId = async () => {
   return generateId();
 };
 
+const getBoolean = (input: any): boolean => {
+  switch(String(input).toLowerCase()) {
+  	case "false": case "no": case "0": case "": return false; 
+  	default: return true;
+  }
+};
+
 export const shortener: Handler = async (req, res) => {
   try {
     const target = addProtocol(req.body.target);
     const targetDomain = URL.parse(target).hostname;
+    const reuse_bool = getBoolean(req.body.reuse);
 
     const queries = await Promise.all([
       env.GOOGLE_SAFE_BROWSING_KEY && cooldownCheck(req.user),
       env.GOOGLE_SAFE_BROWSING_KEY && malwareCheck(req.user, req.body.target),
       req.user && urlCountsCheck(req.user),
       req.user &&
-        req.body.reuse &&
+        reuse_bool &&
         findLink({
           target,
           user_id: req.user.id
@@ -96,6 +104,7 @@ export const shortener: Handler = async (req, res) => {
     const link = await createShortLink(
       {
         ...req.body,
+        reuse_bool,
         address,
         target
       },

--- a/server/__v1/db/link.ts
+++ b/server/__v1/db/link.ts
@@ -14,7 +14,7 @@ import { banHost } from "./host";
 import { banUser } from "./user";
 
 interface CreateLink extends Link {
-  reuse?: boolean;
+  reuse_bool: boolean;
   domainName?: string;
 }
 
@@ -42,7 +42,7 @@ export const createShortLink = async (data: CreateLink, user: UserJoined) => {
   return {
     ...link,
     password: !!data.password,
-    reuse: !!data.reuse,
+    reuse: !!data.reuse_bool,
     shortLink: generateShortLink(data.address, domain),
     shortUrl: generateShortLink(data.address, domain)
   };
@@ -138,7 +138,8 @@ export const findLink = async ({
     .first();
 
   if (link) {
-    redis.set(redisKey, JSON.stringify(link), "EX", 60 * 60 * 2);
+    const newRedisKey = getRedisKey.link(link.address, link.domain_id, link.user_id);
+    redis.set(newRedisKey, JSON.stringify(link), "EX", 60 * 60 * 2);
   }
 
   return link;

--- a/server/handlers/links.ts
+++ b/server/handlers/links.ts
@@ -53,13 +53,14 @@ export const create: Handler = async (req: CreateLinkReq, res) => {
   } = req.body;
   const domain_id = domain ? domain.id : null;
 
-  const targetDomain = URL.parse(target).hostname;
+  const targetDomain = URL.parse(target).hostname;  
+  const reuse_bool = utils.getBoolean(reuse);
 
   const queries = await Promise.all([
     validators.cooldown(req.user),
     validators.malware(req.user, target),
     validators.linksCount(req.user),
-    reuse &&
+    reuse_bool &&
       query.link.find({
         target,
         user_id: req.user.id,

--- a/server/utils/index.ts
+++ b/server/utils/index.ts
@@ -164,3 +164,10 @@ export const sanitize = {
     link: generateShortLink(link.address, link.domain)
   })
 };
+
+export const getBoolean = (input: any): boolean => {
+  switch(String(input).toLowerCase()) {
+  	case "false": case "no": case "0": case "": return false; 
+  	default: return true;
+  }
+};


### PR DESCRIPTION
I've added a simple update to parse a boolean from the `reuse` input when creating links. It was always a truthy value when using the API with `x-www-form-urlencoded` input unless you leave it out or send an empty string which caused unexpected behavior.
I also noticed that new links were always added to the Redis cache as `'undefined--{user_id}'` in the v1 API resulting in calls with `'reuse': true` to return the first link added to cache (which often has a different target), so I added generation of a new key when adding a link to cache. It looks like that has already been done in the v2 API.