### PR TITLE
Improve docker setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,9 @@ You need to have [Node.js](https://nodejs.org/), [PostgreSQL](https://www.postgr
 
 ### Docker
 
-Download the [`docker-compose.yml`](docker-compose.yml) and the [`.docker.env`](.docker.env)-file from the repository and configure the `.docker.env` ([see below](#configuration)). 
-To execute Kutt you simply have to run `docker-compose up -d` command and then the app should be ready on port "3000".
+1. Download the [`docker-compose.yml`](https://raw.githubusercontent.com/thedevs-network/kutt/develop/docker-compose.yml) and the [`.docker.env`](https://raw.githubusercontent.com/thedevs-network/kutt/develop/.docker.env) files.
+2. Rename `.docker.env` to `.env` and fill it properly ([see below](#configuration)).
+3. To execute Kutt you simply have to run `docker-compose up -d` command and then the app should be ready on port "3000".
 
 The `docker-compose.yml` uses the official kutt docker image available on [Docker Hub](https://hub.docker.com/r/kutt/kutt).
 


### PR DESCRIPTION
- Change the docker setup documentation to numbered list for easier reading.
- Add renaming `.docker.env` to `.env` step.
  The first time I read the instruction, I thought that the docker setup read the `.docker.env` directly to supply the env vars.