### PR TITLE
Major performance improvements to redirect lookup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   kutt:
-    image: kutt/kutt
+    image: kingbohica/redsky_kutt
     depends_on:
       - postgres
       - redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   kutt:
-    image: kingbohica/redsky_kutt
+    image: kutt/kutt
     depends_on:
       - postgres
       - redis

--- a/server/__v1/controllers/validateBodyController.ts
+++ b/server/__v1/controllers/validateBodyController.ts
@@ -8,7 +8,7 @@ import axios from "axios";
 import dns from "dns";
 import URL from "url";
 
-import { addProtocol, CustomError, removeWww } from "../../utils";
+import { addProtocol, CustomError, WebUtils } from "../../utils";
 import { addCooldown, banUser } from "../db/user";
 import { getUserLinksCount } from "../db/link";
 import { getDomain } from "../db/domain";
@@ -83,7 +83,7 @@ export const validateUrl: RequestHandler = async (req, res, next) => {
     return res.status(400).json({ error: "URL is not valid." });
 
   // If target is the URL shortener itself
-  const host = removeWww(URL.parse(addProtocol(req.body.target)).host);
+  const host = WebUtils.removeWww(URL.parse(addProtocol(req.body.target)).host);
   if (host === env.DEFAULT_DOMAIN) {
     return res
       .status(400)

--- a/server/handlers/validators.ts
+++ b/server/handlers/validators.ts
@@ -8,7 +8,7 @@ import dns from "dns";
 import URL from "url";
 import ms from "ms";
 
-import { CustomError, addProtocol, removeWww } from "../utils";
+import { CustomError, addProtocol, WebUtils } from "../utils";
 import query from "../queries";
 import knex from "../knex";
 import env from "../env";
@@ -55,7 +55,9 @@ export const createLink = [
         /^(?!https?)(\w+):\/\//.test(value)
     )
     .withMessage("URL is not valid.")
-    .custom(value => removeWww(URL.parse(value).host) !== env.DEFAULT_DOMAIN)
+    .custom(
+      value => WebUtils.removeWww(URL.parse(value).host) !== env.DEFAULT_DOMAIN
+    )
     .withMessage(`${env.DEFAULT_DOMAIN} URLs are not allowed.`),
   body("password")
     .optional({ nullable: true, checkFalsy: true })
@@ -111,7 +113,9 @@ export const createLink = [
     .isString()
     .withMessage("Domain should be string.")
     .customSanitizer(value => value.toLowerCase())
-    .customSanitizer(value => removeWww(URL.parse(value).hostname || value))
+    .customSanitizer(value =>
+      WebUtils.removeWww(URL.parse(value).hostname || value)
+    )
     .custom(async (address, { req }) => {
       if (address === env.DEFAULT_DOMAIN) {
         req.body.domain = null;
@@ -143,7 +147,9 @@ export const editLink = [
         /^(?!https?)(\w+):\/\//.test(value)
     )
     .withMessage("URL is not valid.")
-    .custom(value => removeWww(URL.parse(value).host) !== env.DEFAULT_DOMAIN)
+    .custom(
+      value => WebUtils.removeWww(URL.parse(value).host) !== env.DEFAULT_DOMAIN
+    )
     .withMessage(`${env.DEFAULT_DOMAIN} URLs are not allowed.`),
   body("address")
     .optional({ checkFalsy: true, nullable: true })
@@ -201,7 +207,7 @@ export const addDomain = [
     .trim()
     .customSanitizer(value => {
       const parsed = URL.parse(value);
-      return removeWww(parsed.hostname || parsed.href);
+      return WebUtils.removeWww(parsed.hostname || parsed.href);
     })
     .custom(value => urlRegex({ exact: true, strict: false }).test(value))
     .custom(value => value !== env.DEFAULT_DOMAIN)
@@ -244,7 +250,8 @@ export const reportLink = [
     })
     .customSanitizer(addProtocol)
     .custom(
-      value => removeWww(URL.parse(value).hostname) === env.DEFAULT_DOMAIN
+      value =>
+        WebUtils.removeWww(URL.parse(value).hostname) === env.DEFAULT_DOMAIN
     )
     .withMessage(`You can only report a ${env.DEFAULT_DOMAIN} link.`)
 ];

--- a/server/migrations/20200211220920_constraints.ts
+++ b/server/migrations/20200211220920_constraints.ts
@@ -11,20 +11,28 @@ export async function up(knex: Knex): Promise<any> {
 
   await Promise.all([
     knex.raw(`
-      ALTER TABLE domains
-      DROP CONSTRAINT domains_user_id_foreign,
+        ALTER TABLE domains
+        DROP CONSTRAINT domains_user_id_foreign,
       ADD CONSTRAINT domains_user_id_foreign
         FOREIGN KEY (user_id) 
         REFERENCES users (id)
         ON DELETE SET NULL;
     `),
     knex.raw(`
-      ALTER TABLE links
-      DROP CONSTRAINT links_user_id_foreign,
+        ALTER TABLE links
+        DROP CONSTRAINT links_user_id_foreign,
       ADD CONSTRAINT links_user_id_foreign
         FOREIGN KEY (user_id)
         REFERENCES users (id)
         ON DELETE CASCADE;
+    `),
+    knex.raw(`
+        CREATE INDEX links_address_index
+            ON links (address);
+        CREATE INDEX links_domain_id_index
+            ON links (domain_id);
+        CREATE INDEX links_user_id_index
+            ON links (user_id);
     `),
     knex.raw(`
       ALTER TABLE visits

--- a/server/queries/link.ts
+++ b/server/queries/link.ts
@@ -93,8 +93,14 @@ export const get = async (match: Partial<Link>, params: GetParams) => {
   return links;
 };
 
-export const find = async (match: Partial<Link>): Promise<Link> => {
-  if (match.address && match.domain_id) {
+export const find = async (
+  match: Partial<Link>,
+  isDefaultDomain: boolean = false
+): Promise<Link> => {
+  if (
+    (match.address && match.domain_id) ||
+    (match.address && isDefaultDomain)
+  ) {
     const key = redis.key.link(match.address, match.domain_id);
     const cachedLink = await redis.get(key);
     if (cachedLink) return JSON.parse(cachedLink);

--- a/server/queues/visit.ts
+++ b/server/queues/visit.ts
@@ -3,7 +3,7 @@ import geoip from "geoip-lite";
 import URL from "url";
 
 import query from "../queries";
-import { getStatsLimit, removeWww } from "../utils";
+import { getStatsLimit, WebUtils } from "../utils";
 
 const browsersList = ["IE", "Firefox", "Chrome", "Opera", "Safari", "Edge"];
 const osList = ["Windows", "Mac OS", "Linux", "Android", "iOS"];
@@ -22,7 +22,7 @@ export default function({ data }) {
     const [browser = "Other"] = browsersList.filter(filterInBrowser(agent));
     const [os = "Other"] = osList.filter(filterInOs(agent));
     const referrer =
-      data.referrer && removeWww(URL.parse(data.referrer).hostname);
+      data.referrer && WebUtils.removeWww(URL.parse(data.referrer).hostname);
     const location = geoip.lookup(data.realIP);
     const country = location && location.country;
     tasks.push(

--- a/server/utils/index.ts
+++ b/server/utils/index.ts
@@ -22,6 +22,28 @@ export class CustomError extends Error {
   }
 }
 
+export class WebUtils {
+  /** Removes the leading www on a host url
+   * @name removeWww
+   * @param host
+   * @returns string
+   */
+  static removeWww = (host = "") => {
+    return host.replace("www.", "");
+  };
+
+  /**
+   * Determines if the given domain is the default domain from the env
+   * @name isDefaultDomain
+   * @param hostUrl
+   * @returns boolean
+   */
+  static isDefaultDomain = (hostUrl: string = ""): boolean => {
+    hostUrl = WebUtils.removeWww(hostUrl);
+    return !!(hostUrl === env.DEFAULT_DOMAIN);
+  };
+}
+
 export const isAdmin = (email: string): boolean =>
   env.ADMIN_EMAILS.split(",")
     .map(e => e.trim())
@@ -40,12 +62,15 @@ export const signToken = (user: UserJoined) =>
     env.JWT_SECRET
   );
 
-export const generateId = async (domain_id: number = null) => {
+export const generateId = async (
+  domain_id: number = null,
+  isDefaultDomain: boolean = false
+) => {
   const address = generate(
     "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890",
     env.LINK_LENGTH
   );
-  const link = await query.link.find({ address, domain_id });
+  const link = await query.link.find({ address, domain_id }, isDefaultDomain);
   if (!link) return address;
   return generateId(domain_id);
 };
@@ -163,8 +188,4 @@ export const sanitize = {
     password: !!link.password,
     link: generateShortLink(link.address, link.domain)
   })
-};
-
-export const removeWww = (host = "") => {
-  return host.replace("www.", "");
 };


### PR DESCRIPTION
Fixes an issue that was taking place for the default domain. We had an issue where we weren't allowed to add the default domain to the domain table and would cache miss on each and every redirect links.find call against the default domain.

With the standard Kutt processes, a single redirect request takes between 60 and 80 ms on a local machine, and 120 -150 ms on a small Ubuntu server.
 
After implementing a cache check on the default domain, a local redirect request dropped to 5-10ms. 

I also found that be default there weren't indexes to the links.address column, even though that is where the query primarily takes place. Adding an index to this a local redirect request (without the cache optimizations in place) took between 7-15 ms for a read. 

Changes the utils.removeWww method to a static class method for accessibility locally for the default domain check. 