### PR TITLE
Performance improvements

### DIFF
--- a/server/handlers/links.ts
+++ b/server/handlers/links.ts
@@ -66,11 +66,15 @@ export const create: Handler = async (req: CreateLinkReq, res) => {
         domain_id
       }),
     customurl &&
-      query.link.find({
-        address: customurl,
-        domain_id
-      }),
-    !customurl && utils.generateId(domain_id),
+      query.link.find(
+        {
+          address: customurl,
+          domain_id
+        },
+        utils.isDefaultDomain(req.headers.host)
+      ),
+    !customurl &&
+      utils.generateId(domain_id, utils.isDefaultDomain(req.headers.host)),
     validators.bannedDomain(targetDomain),
     validators.bannedHost(targetDomain)
   ]);
@@ -273,10 +277,13 @@ export const redirect = (app: ReturnType<typeof next>): Handler => async (
 
   // 2. Get link
   const address = req.params.id.replace("+", "");
-  const link = await query.link.find({
-    address,
-    domain_id: domain ? domain.id : null
-  });
+  const link = await query.link.find(
+    {
+      address,
+      domain_id: domain ? domain.id : null
+    },
+    utils.isDefaultDomain(host)
+  );
 
   // 3. When no link, if has domain redirect to domain's homepage
   // otherwise rediredt to 404

--- a/server/migrations/20200211220920_constraints.ts
+++ b/server/migrations/20200211220920_constraints.ts
@@ -27,6 +27,14 @@ export async function up(knex: Knex): Promise<any> {
         ON DELETE CASCADE;
     `),
     knex.raw(`
+        CREATE INDEX links_address_index
+            ON links (address);
+        CREATE INDEX links_domain_id_index
+            ON links (domain_id);
+        CREATE INDEX links_user_id_index
+            ON links (user_id);
+    `),
+    knex.raw(`
       ALTER TABLE visits
       DROP CONSTRAINT visits_link_id_foreign,
       ADD CONSTRAINT visits_link_id_foreign

--- a/server/queries/link.ts
+++ b/server/queries/link.ts
@@ -93,8 +93,14 @@ export const get = async (match: Partial<Link>, params: GetParams) => {
   return links;
 };
 
-export const find = async (match: Partial<Link>): Promise<Link> => {
-  if (match.address && match.domain_id) {
+export const find = async (
+  match: Partial<Link>,
+  isDefaultDomain: boolean = false
+): Promise<Link> => {
+  if (
+    (match.address && match.domain_id) ||
+    (match.address && isDefaultDomain)
+  ) {
     const key = redis.key.link(match.address, match.domain_id);
     const cachedLink = await redis.get(key);
     if (cachedLink) return JSON.parse(cachedLink);

--- a/server/utils/index.ts
+++ b/server/utils/index.ts
@@ -40,12 +40,15 @@ export const signToken = (user: UserJoined) =>
     env.JWT_SECRET
   );
 
-export const generateId = async (domain_id: number = null) => {
+export const generateId = async (
+  domain_id: number = null,
+  isDefaultDomain: boolean = false
+) => {
   const address = generate(
     "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890",
     env.LINK_LENGTH
   );
-  const link = await query.link.find({ address, domain_id });
+  const link = await query.link.find({ address, domain_id }, isDefaultDomain);
   if (!link) return address;
   return generateId(domain_id);
 };
@@ -167,4 +170,9 @@ export const sanitize = {
 
 export const removeWww = (host = "") => {
   return host.replace("www.", "");
+};
+
+export const isDefaultDomain = (hostUrl: string = ""): boolean => {
+  hostUrl = hostUrl.replace("www.", "");
+  return !!(hostUrl === env.DEFAULT_DOMAIN);
 };


### PR DESCRIPTION
Significant performance improvements

Fixes an issue that was taking place for the default domain. We had an issue where we weren't allowed to add the default domain to the domain table and would cache miss on each and every redirect links.find call against the default domain.

With the standard Kutt processes, a single redirect request takes between 60 and 80 ms on a local machine, and 120 -150 ms on a small Ubuntu server.

After implementing a cache check on the default domain, a local redirect request dropped to 5-10ms.

I also found that be default there weren't indexes to the links.address column, even though that is where the query primarily takes place. Adding an index to this a local redirect request (without the cache optimizations in place) took between 7-15 ms for a read.

* Adds indexes on database for significantly faster lookups.
* Adds a check for default domain against the cache. As default domain can't be added to the custom domains, we need to have a default domain check for cache