### PR TITLE
feat: add endpoint edit by address

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,13 +70,6 @@ You need to have [Node.js](https://nodejs.org/), [PostgreSQL](https://www.postgr
 4. Run for development: `npm run dev`.
 5. Run for production: `npm run build` then `npm start`.
 
-
-Postgres local
-
-```
-docker run -d --name dev-postgres -e POSTGRES_PASSWORD=Pass2020! -v ~/postgres-data/:/var/lib/postgresql/data -p 5432:5432 postgres
-```
-
 ### Docker
 
 Download the [`docker-compose.yml`](docker-compose.yml) and the [`.docker.env`](.docker.env)-file from the repository and configure the `.docker.env` ([see below](#configuration)). 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,13 @@ You need to have [Node.js](https://nodejs.org/), [PostgreSQL](https://www.postgr
 4. Run for development: `npm run dev`.
 5. Run for production: `npm run build` then `npm start`.
 
+
+Postgres local
+
+```
+docker run -d --name dev-postgres -e POSTGRES_PASSWORD=Pass2020! -v ~/postgres-data/:/var/lib/postgresql/data -p 5432:5432 postgres
+```
+
 ### Docker
 
 Download the [`docker-compose.yml`](docker-compose.yml) and the [`.docker.env`](.docker.env)-file from the repository and configure the `.docker.env` ([see below](#configuration)). 

--- a/server/handlers/links.ts
+++ b/server/handlers/links.ts
@@ -159,7 +159,7 @@ export const edit: Handler = async (req, res) => {
   return res.status(200).send(utils.sanitize.link({ ...link, ...updatedLink }));
 };
 
-export const editByShortLink: Handler = async (req, res) => {
+export const editByAddress: Handler = async (req, res) => {
   const { address, target, description, expire_in } = req.body;
 
   if (!address && !target) {
@@ -167,7 +167,7 @@ export const editByShortLink: Handler = async (req, res) => {
   }
 
   const link = await query.link.find({
-    address: req.query.shortLink,
+    address: req.query.address,
     ...(!req.user.admin && { user_id: req.user.id })
   });
 

--- a/server/handlers/links.ts
+++ b/server/handlers/links.ts
@@ -166,8 +166,6 @@ export const editByShortLink: Handler = async (req, res) => {
     throw new CustomError("Should at least update one field.");
   }
 
-  console.log("EEE", req.query.shortLink);
-
   const link = await query.link.find({
     address: req.query.shortLink,
     ...(!req.user.admin && { user_id: req.user.id })

--- a/server/handlers/validators.ts
+++ b/server/handlers/validators.ts
@@ -1,4 +1,4 @@
-import { body, param } from "express-validator";
+import { body, param, query as validatorQuery } from "express-validator";
 import { isAfter, subDays, subHours, addMilliseconds } from "date-fns";
 import urlRegex from "url-regex";
 import { promisify } from "util";
@@ -180,6 +180,60 @@ export const editLink = [
   param("id", "ID is invalid.")
     .exists({ checkFalsy: true, checkNull: true })
     .isLength({ min: 36, max: 36 })
+];
+
+export const editByShortLink = [
+  body("target")
+    .optional({ checkFalsy: true, nullable: true })
+    .isString()
+    .trim()
+    .isLength({ min: 1, max: 2040 })
+    .withMessage("Maximum URL length is 2040.")
+    .customSanitizer(addProtocol)
+    .custom(
+      value =>
+        urlRegex({ exact: true, strict: false }).test(value) ||
+        /^(?!https?)(\w+):\/\//.test(value)
+    )
+    .withMessage("URL is not valid.")
+    .custom(value => removeWww(URL.parse(value).host) !== env.DEFAULT_DOMAIN)
+    .withMessage(`${env.DEFAULT_DOMAIN} URLs are not allowed.`),
+  body("address")
+    .optional({ checkFalsy: true, nullable: true })
+    .isString()
+    .trim()
+    .isLength({ min: 1, max: 64 })
+    .withMessage("Custom URL length must be between 1 and 64.")
+    .custom(value => /^[a-zA-Z0-9-_]+$/g.test(value))
+    .withMessage("Custom URL is not valid")
+    .custom(value => !preservedUrls.some(url => url.toLowerCase() === value))
+    .withMessage("You can't use this custom URL."),
+  body("expire_in")
+    .optional({ nullable: true, checkFalsy: true })
+    .isString()
+    .trim()
+    .custom(value => {
+      try {
+        return !!ms(value);
+      } catch {
+        return false;
+      }
+    })
+    .withMessage("Expire format is invalid. Valid examples: 1m, 8h, 42 days.")
+    .customSanitizer(ms)
+    .custom(value => value >= ms("1m"))
+    .withMessage("Minimum expire time should be '1 minute'.")
+    .customSanitizer(value => addMilliseconds(new Date(), value).toISOString()),
+  body("description")
+    .optional({ nullable: true, checkFalsy: true })
+    .isString()
+    .trim()
+    .isLength({ min: 0, max: 2040 })
+    .withMessage("Description length must be between 0 and 2040."),
+  validatorQuery("shortLink", "ShortLink is invalid.").exists({
+    checkFalsy: true,
+    checkNull: true
+  })
 ];
 
 export const redirectProtected = [

--- a/server/handlers/validators.ts
+++ b/server/handlers/validators.ts
@@ -182,7 +182,7 @@ export const editLink = [
     .isLength({ min: 36, max: 36 })
 ];
 
-export const editByShortLink = [
+export const editByAddress = [
   body("target")
     .optional({ checkFalsy: true, nullable: true })
     .isString()
@@ -230,7 +230,7 @@ export const editByShortLink = [
     .trim()
     .isLength({ min: 0, max: 2040 })
     .withMessage("Description length must be between 0 and 2040."),
-  validatorQuery("shortLink", "ShortLink is invalid.").exists({
+  validatorQuery("address", "Address is invalid.").exists({
     checkFalsy: true,
     checkNull: true
   })

--- a/server/routes/links.ts
+++ b/server/routes/links.ts
@@ -31,6 +31,15 @@ router.post(
 );
 
 router.patch(
+  "/edit",
+  asyncHandler(auth.apikey),
+  asyncHandler(auth.jwt),
+  validators.editByShortLink,
+  asyncHandler(helpers.verify),
+  asyncHandler(link.editByShortLink)
+);
+
+router.patch(
   "/:id",
   asyncHandler(auth.apikey),
   asyncHandler(auth.jwt),

--- a/server/routes/links.ts
+++ b/server/routes/links.ts
@@ -34,9 +34,9 @@ router.patch(
   "/edit",
   asyncHandler(auth.apikey),
   asyncHandler(auth.jwt),
-  validators.editByShortLink,
+  validators.editByAddress,
   asyncHandler(helpers.verify),
-  asyncHandler(link.editByShortLink)
+  asyncHandler(link.editByAddress)
 );
 
 router.patch(


### PR DESCRIPTION
Right now Kutt only support to edit short link by uuid via this API: `PATCH v2/api/:id`

Added new API `PATCH v2/api/edit?address=xYZC` to support update short link by address.