### PR TITLE
Changed 301 Redirect to 302

### DIFF
--- a/server/__v1/controllers/linkController.ts
+++ b/server/__v1/controllers/linkController.ts
@@ -133,7 +133,7 @@ export const goToLink: Handler = async (req, res, next) => {
   if (!link) {
     if (host !== env.DEFAULT_DOMAIN) {
       if (!domain || !domain.homepage) return next();
-      return res.redirect(301, domain.homepage);
+      return res.redirect(302, domain.homepage);
     }
     return next();
   }
@@ -274,7 +274,7 @@ export const customDomainRedirection: Handler = async (req, res, next) => {
   ) {
     const domain = await getDomain({ address: host });
     return res.redirect(
-      301,
+      302,
       (domain && domain.homepage) || `https://${env.DEFAULT_DOMAIN + path}`
     );
   }

--- a/server/handlers/links.ts
+++ b/server/handlers/links.ts
@@ -281,7 +281,7 @@ export const redirect = (app: ReturnType<typeof next>): Handler => async (
   // 3. When no link, if has domain redirect to domain's homepage
   // otherwise rediredt to 404
   if (!link) {
-    return res.redirect(301, domain ? domain.homepage : "/404");
+    return res.redirect(302, domain ? domain.homepage : "/404");
   }
 
   // 4. If link is banned, redirect to banned page.
@@ -388,7 +388,7 @@ export const redirectCustomDomain: Handler = async (req, res, next) => {
       ? domain.homepage
       : `https://${env.DEFAULT_DOMAIN + path}`;
 
-    return res.redirect(301, redirectURL);
+    return res.redirect(302, redirectURL);
   }
 
   return next();


### PR DESCRIPTION
When a user tries to reach a url that does not yet redirect to a different url, the user is permanently redirected to the 404 page (or homepage in some cases).
I would suggest to use the `302` HTTP-code instead of the `301` code, otherwise users might not be able to access a shortened link without clearing their cache.

Example:
- User tries to access `mydomain.com/test` but gets `301` redirected to `mydomain.com/404`.
- User now adds a new short link to some url with the custom address of `mydomain.com/test`
- User cannot reach said custom address, because the user has previously been permanently redirected to the 404 page