### PR TITLE
create-.env-from-env - fixes #636

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,12 +13,15 @@ RUN npm install
 COPY . .
 
 # Give permission to run script
-RUN chmod +x ./wait-for-it.sh
+RUN chmod +x ./wait-for-it.sh ./entrypoint.sh
 
 # Build files
 RUN npm run build
 
 EXPOSE 3000
+
+# entrypoint
+ENTRYPOINT [ "./entrypoint.sh" ]
 
 # Running the app
 CMD [ "npm", "start" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   kutt:
-    image: kutt/kutt
+    build: .
     depends_on:
       - postgres
       - redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,6 @@ version: "3"
 services:
   kutt:
     image: kutt/kutt
-    #build: .
     depends_on:
       - postgres
       - redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,8 @@ version: "3"
 
 services:
   kutt:
-    build: .
+    image: kutt/kutt
+    #build: .
     depends_on:
       - postgres
       - redis

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,7 +12,7 @@ for param in \
     DISALLOW_ANONYMOUS_LINKS \
     DISALLOW_REGISTRATION \
     SENTRY_PUBLIC_DSN \
-    DISALLOW_CUSTOMDOMAINS \
+    DISALLOW_DOMAIN \
     ; do
     if [ -n "${!param}" ] ; then
         echo "$param=\"${!param}\"" >>.env

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+echo "entrypoint.sh"
+# creates .env file for next.config.js
+for param in \
+    CONTACT_EMAIL \
+    SITE_NAME \
+    DEFAULT_DOMAIN \
+    RECAPTCHA_SITE_KEY \
+    GOOGLE_ANALYTICS \
+    REPORT_EMAIL \
+    DISALLOW_ANONYMOUS_LINKS \
+    DISALLOW_REGISTRATION \
+    SENTRY_PUBLIC_DSN \
+    DISALLOW_CUSTOMDOMAINS \
+    ; do
+    if [ -n "${!param}" ] ; then
+        echo "$param=\"${!param}\"" >>.env
+    fi
+done
+
+echo "Running $@"
+exec "$@"


### PR DESCRIPTION
next.config.js is using `require("dotenv").config();` - but there is no .env inside the container!
The .env is outside the container when using docker-compose. Documentation says nothing about this.

I've added an entrypoint.sh which creates an `.env`-file from the ENV-Variables .

Fixes #636 