### PR TITLE
Feature: default https

### DIFF
--- a/server/utils/index.ts
+++ b/server/utils/index.ts
@@ -52,7 +52,7 @@ export const generateId = async (domain_id: number = null) => {
 
 export const addProtocol = (url: string): string => {
   const hasProtocol = /^\w+:\/\//.test(url);
-  return hasProtocol ? url : `http://${url}`;
+  return hasProtocol ? url : `https://${url}`;
 };
 
 export const generateShortLink = (id: string, domain?: string): string => {


### PR DESCRIPTION
Default is nowadays https. If a user does not explicitly types  `http://` with this PR  `https://` gets prepended