### PR TITLE
Minor improvements on edit link password

### DIFF
--- a/client/components/LinksTable.tsx
+++ b/client/components/LinksTable.tsx
@@ -397,7 +397,7 @@ const Row: FC<RowProps> = ({ index, link, setDeleteModal }) => {
                     {...password({
                       name: "password"
                     })}
-                    placeholder={link.password ? "●●●●●●●" : "Password..."}
+                    placeholder={link.password ? "••••••••" : "Password..."}
                     autocomplete="off"
                     data-lpignore
                     pl={[3, 24]}

--- a/server/handlers/validators.ts
+++ b/server/handlers/validators.ts
@@ -147,8 +147,6 @@ export const editLink = [
     .withMessage(`${env.DEFAULT_DOMAIN} URLs are not allowed.`),
   body("password")
     .optional({ nullable: true, checkFalsy: true })
-    .custom(checkUser)
-    .withMessage("Only users can use this field.")
     .isString()
     .isLength({ min: 3, max: 64 })
     .withMessage("Password length must be between 3 and 64."),


### PR DESCRIPTION
- Use password dot unicode character for password input's placeholder.
- Remove check user validation. Since there always would be an authenticated user and this check would no longer be needed.