### PR TITLE
Fix: PublicRuntimeEnvironment not available in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12-alpine
+FROM node:lts-alpine
 
 RUN apk add --update bash
 
@@ -11,6 +11,9 @@ RUN npm install
 
 # Copying source files
 COPY . .
+
+# Remove Env variables from container before building
+RUN rm -rf .env
 
 # Give permission to run script
 RUN chmod +x ./wait-for-it.sh

--- a/client/consts/consts.ts
+++ b/client/consts/consts.ts
@@ -2,11 +2,8 @@ import getConfig from "next/config";
 
 const { publicRuntimeConfig } = getConfig();
 
-export const DISALLOW_ANONYMOUS_LINKS =
-  publicRuntimeConfig.DISALLOW_ANONYMOUS_LINKS === "true";
-
-export const DISALLOW_REGISTRATION =
-  publicRuntimeConfig.DISALLOW_REGISTRATION === "true";
+export const { DISALLOW_ANONYMOUS_LINKS } = publicRuntimeConfig;
+export const { DISALLOW_REGISTRATION } = publicRuntimeConfig;
 
 export enum APIv2 {
   AuthLogin = "/api/v2/auth/login",

--- a/client/types.ts
+++ b/client/types.ts
@@ -1,3 +1,5 @@
+export type { PublicRuntimeConfig } from "../server/env";
+
 export interface TokenPayload {
   iss: "ApiAuth";
   sub: string;

--- a/server/env.ts
+++ b/server/env.ts
@@ -41,4 +41,16 @@ const env = cleanEnv(process.env, {
   CONTACT_EMAIL: str({ default: "" })
 });
 
+export const publicRuntimeConfig = {
+  x: 3,
+  CONTACT_EMAIL: env?.CONTACT_EMAIL,
+  SITE_NAME: env?.SITE_NAME,
+  DEFAULT_DOMAIN: env?.DEFAULT_DOMAIN,
+  RECAPTCHA_SITE_KEY: env?.RECAPTCHA_SITE_KEY,
+  REPORT_EMAIL: env?.REPORT_EMAIL,
+  DISALLOW_ANONYMOUS_LINKS: env.DISALLOW_ANONYMOUS_LINKS,
+  DISALLOW_REGISTRATION: env?.DISALLOW_REGISTRATION
+};
+
+export type PublicRuntimeConfig = typeof publicRuntimeConfig;
 export default env;

--- a/server/server.ts
+++ b/server/server.ts
@@ -1,4 +1,4 @@
-import env from "./env";
+import env, { publicRuntimeConfig } from "./env";
 
 import asyncHandler from "express-async-handler";
 import cookieParser from "cookie-parser";
@@ -18,7 +18,11 @@ import "./cron";
 import "./passport";
 
 const port = env.PORT;
-const app = nextApp({ dir: "./client", dev: env.isDev });
+const app = nextApp({
+  dir: "./client",
+  dev: env.isDev,
+  conf: { publicRuntimeConfig }
+});
 const handle = app.getRequestHandler();
 
 app.prepare().then(async () => {


### PR DESCRIPTION
Fixes #656
This PR fixes issues arising from `publicRuntimeConfig` not being loaded when using docker.

This issue occurs because the values of `publicRuntimeConfig` are generated during the build process. 
This prevents the values supplied by .env files later on from taking effects.

The PR fixes this issue by supplying `publicRuntimeConfig` to the nextApp when it is loaded by `server/server.js`
