### PR TITLE
Fix: empty `publicRuntimeEnvironment` in docker and Kubernetes

### DIFF
--- a/client/consts/consts.ts
+++ b/client/consts/consts.ts
@@ -2,11 +2,8 @@ import getConfig from "next/config";
 
 const { publicRuntimeConfig } = getConfig();
 
-export const DISALLOW_ANONYMOUS_LINKS =
-  publicRuntimeConfig.DISALLOW_ANONYMOUS_LINKS === "true";
-
-export const DISALLOW_REGISTRATION =
-  publicRuntimeConfig.DISALLOW_REGISTRATION === "true";
+export const { DISALLOW_ANONYMOUS_LINKS } = publicRuntimeConfig;
+export const { DISALLOW_REGISTRATION } = publicRuntimeConfig;
 
 export enum APIv2 {
   AuthLogin = "/api/v2/auth/login",

--- a/next.config.js
+++ b/next.config.js
@@ -1,13 +1,14 @@
-const { parsed: localEnv } = require("dotenv").config();
+require("dotenv").config();
+const env = process.env || {};
 
 module.exports = {
   publicRuntimeConfig: {
-    CONTACT_EMAIL: localEnv && localEnv.CONTACT_EMAIL,
-    SITE_NAME: localEnv && localEnv.SITE_NAME,
-    DEFAULT_DOMAIN: localEnv && localEnv.DEFAULT_DOMAIN,
-    RECAPTCHA_SITE_KEY: localEnv && localEnv.RECAPTCHA_SITE_KEY,
-    REPORT_EMAIL: localEnv && localEnv.REPORT_EMAIL,
-    DISALLOW_ANONYMOUS_LINKS: localEnv && localEnv.DISALLOW_ANONYMOUS_LINKS,
-    DISALLOW_REGISTRATION: localEnv && localEnv.DISALLOW_REGISTRATION
+    CONTACT_EMAIL: env.CONTACT_EMAIL,
+    SITE_NAME: env.SITE_NAME,
+    DEFAULT_DOMAIN: env.DEFAULT_DOMAIN,
+    RECAPTCHA_SITE_KEY: env.RECAPTCHA_SITE_KEY,
+    REPORT_EMAIL: env.REPORT_EMAIL,
+    DISALLOW_ANONYMOUS_LINKS: env.DISALLOW_ANONYMOUS_LINKS === "true",
+    DISALLOW_REGISTRATION: env.DISALLOW_REGISTRATION === "true"
   }
 };


### PR DESCRIPTION
Fixes #656 #636

Issue #656 occurs because the configuration `DISALLOW_ANONYMOUS_LINKS` is not available to `publicRuntimeConfig`
when using container orchestration. 

This PR allows both .env file and values from `process.env` to be used to configure app, making it possible to use any type of environmental variables