### PR TITLE
Support links with dashes

### DIFF
--- a/server/handlers/validators.ts
+++ b/server/handlers/validators.ts
@@ -52,7 +52,7 @@ export const createLink = [
     .custom(
       value =>
         urlRegex({ exact: true, strict: false }).test(value) ||
-        /^(?!https?)(\w+):\/\//.test(value)
+        /^(?!https?)([\w-]+):\/\//.test(value)
     )
     .withMessage("URL is not valid.")
     .custom(value => removeWww(URL.parse(value).host) !== env.DEFAULT_DOMAIN)
@@ -140,7 +140,7 @@ export const editLink = [
     .custom(
       value =>
         urlRegex({ exact: true, strict: false }).test(value) ||
-        /^(?!https?)(\w+):\/\//.test(value)
+        /^(?!https?)([\w-]+):\/\//.test(value)
     )
     .withMessage("URL is not valid.")
     .custom(value => removeWww(URL.parse(value).host) !== env.DEFAULT_DOMAIN)

--- a/server/handlers/validators.ts
+++ b/server/handlers/validators.ts
@@ -52,7 +52,7 @@ export const createLink = [
     .custom(
       value =>
         urlRegex({ exact: true, strict: false }).test(value) ||
-        /^(?!https?)([\w-]+):\/\//.test(value)
+        /^(?!https?)(\w[\w-]+):\/\//.test(value)
     )
     .withMessage("URL is not valid.")
     .custom(value => removeWww(URL.parse(value).host) !== env.DEFAULT_DOMAIN)
@@ -140,7 +140,7 @@ export const editLink = [
     .custom(
       value =>
         urlRegex({ exact: true, strict: false }).test(value) ||
-        /^(?!https?)([\w-]+):\/\//.test(value)
+        /^(?!https?)(\w[\w-]+):\/\//.test(value)
     )
     .withMessage("URL is not valid.")
     .custom(value => removeWww(URL.parse(value).host) !== env.DEFAULT_DOMAIN)


### PR DESCRIPTION
## Support link with dashes
Links with dash are not supported,  example `itms-services://0.0.0.0?action=download-manifest&url=https://randomlinkdoesntmatter.com`
Changing create and edit regex validation