### PR TITLE
Updated README.md to reflect the correct 'DEFAULT_DOMAIN' value.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The `docker-compose.yml` uses the official kutt docker image available on [Docke
 
 For the minimal configuration the following settings have to be changed in the `.env`-file:
 
-- **DEFAULT_DOMAIN**: The domain of your kutt instance
+- **DEFAULT_DOMAIN**: The domain of your kutt instance written in **FQDN** notation. Example, "host.example.com". This is also important for front-end Reverse Proxies.
 - **DB_**: The DB credentials (when you use docker-compose you can skip these)
 - **ADMIN_EMAILS**: A comma-separated list of the administrator-accounts
 - **RECAPTCHA_**: Enter your credentials to use reCaptchas or delete this setting if you don't want to use it


### PR DESCRIPTION
There is an extremely important bit of information in the Docker .env section that's surprisingly missing.

You see, the most common use case for this app is to be able to host it in a private server in the cloud, front-ended by a reverse proxy. And when we add TLS termination into the MIX as well, it becomes all the more important to advise the general audience that the 'DEFAULT_Domain' is supposed to contain the FQDN value (inclusive of the host portion) and not just the domain portion. If only the domain portion is included, obvious strange behaviours tend to occur, including a scenario where an NGINX reverse proxy redirects any kutt-owned subdomains to a root domain hosted on the same server if the 'DEFAULT_DOMAIN'.