### PR TITLE
Fix Mandatory email setup

### DIFF
--- a/client/pages/login.tsx
+++ b/client/pages/login.tsx
@@ -34,7 +34,7 @@ const LoginPage = () => {
   const { isAuthenticated } = useStoreState((s) => s.auth);
   const login = useStoreActions((s) => s.auth.login);
   const [error, setError] = useState("");
-  const [verifying, setVerifying] = useState(false);
+  const [message, setMessage] = useState("");
   const [loading, setLoading] = useState({ login: false, signup: false });
   const [formState, { email, password, label }] = useFormState<{
     email: string;
@@ -79,8 +79,8 @@ const LoginPage = () => {
       if (type === "signup" && !DISALLOW_REGISTRATION) {
         setLoading((s) => ({ ...s, signup: true }));
         try {
-          await axios.post(APIv2.AuthSignup, { email, password });
-          setVerifying(true);
+          const res = await axios.post(APIv2.AuthSignup, { email, password });
+          setMessage(res.data.message);
         } catch (error) {
           setError(error.response.data.error);
         }
@@ -97,10 +97,9 @@ const LoginPage = () => {
   return (
     <AppWrapper>
       <ColCenterV maxWidth="100%" px={3} flex="0 0 auto" mt={4}>
-        {verifying ? (
+        {message ? (
           <H2 textAlign="center" light>
-            A verification email has been sent to{" "}
-            <Email>{formState.values.email}</Email>.
+            {message}
           </H2>
         ) : (
           <LoginForm id="login-form" onSubmit={onSubmit("login")}>

--- a/server/handlers/auth.ts
+++ b/server/handlers/auth.ts
@@ -120,9 +120,16 @@ export const signup: Handler = async (req, res) => {
     req.user
   );
 
+  if (!process.env.MAIL_HOST) {
+    return res
+      .status(201)
+      .send({ message: "Your account has been created successfully." });
+  }
   await mail.verification(user);
 
-  return res.status(201).send({ message: "Verification email has been sent." });
+  return res
+    .status(201)
+    .send({ message: `Verification email has been sent to ${user.email}.` });
 };
 
 export const token: Handler = async (req, res) => {

--- a/server/queries/user.ts
+++ b/server/queries/user.ts
@@ -36,7 +36,8 @@ export const add = async (params: Add, user?: User) => {
     email: params.email,
     password: params.password,
     verification_token: uuid(),
-    verification_expires: addMinutes(new Date(), 60).toISOString()
+    verification_expires: addMinutes(new Date(), 60).toISOString(),
+    verified: process.env.MAIL_HOST ? false : true
   };
 
   if (user) {


### PR DESCRIPTION
This fixes #689

The Mail setup was mandatory, so this makes the project not flexible, some people might want to use it and deploy it without email confirmation of the signup, or even in the dev environment,

## The solution
If the env variable ``MAIL_HOST`` is not set, the system will not send a confirmation email, and the new accounts will be verified by default,

Thanks.

``PART OF GTC OPEN-SOURCE INITIATIVE``