### PR TITLE
feat: build arm images

### DIFF
--- a/.github/workflows/docker-build-latest.yaml
+++ b/.github/workflows/docker-build-latest.yaml
@@ -32,6 +32,7 @@ jobs:
         name: Build and push
         uses: docker/build-push-action@v2
         with:
+          platforms: linux/amd64,linux/arm64
           context: .
           push: true
           tags: ${{ env.dockerhub_repository }}:${{ env.dockerhub_tag }}

--- a/.github/workflows/docker-build-release.yaml
+++ b/.github/workflows/docker-build-release.yaml
@@ -30,6 +30,7 @@ jobs:
         name: Build and push
         uses: docker/build-push-action@v2
         with:
+          platforms: linux/amd64,linux/arm64
           context: .
           push: true
           tags: ${{ env.dockerhub_repository }}:${{ github.event.release.tag_name }}, ${{ env.dockerhub_repository }}:latest


### PR DESCRIPTION
Kutt used to provide arm images for versions before v3. I'm assuming the build works fine because there's an arm version pushed for v3 which seems to be a mistake; but the Dockerfile may need to be adapted if it doesn't support ARM.