### PR TITLE
Allow passing passwords as a HTTP Auth parameter in links

### DIFF
--- a/server/handlers/links.handler.js
+++ b/server/handlers/links.handler.js
@@ -504,15 +504,15 @@ async function redirect(req, res, next) {
 
   // 6. If link is protected, redirect to password page
   if (link.password) {
-    if ('authorization' in req.headers) {
+    if ("authorization" in req.headers) {
       const auth = req.headers.authorization;
-      const firstSpace = auth.indexOf(' ');
+      const firstSpace = auth.indexOf(" ");
       if (firstSpace !== -1) {
         const method = auth.slice(0, firstSpace);
         const payload = auth.slice(firstSpace + 1);
-        if (method === 'Basic') {
-          const decoded = Buffer.from(payload, 'base64').toString('utf8');
-          const colon = decoded.indexOf(':');
+        if (method === "Basic") {
+          const decoded = Buffer.from(payload, "base64").toString("utf8");
+          const colon = decoded.indexOf(":");
           if (colon !== -1) {
             const password = decoded.slice(colon + 1);
             const matches = await bcrypt.compare(password, link.password);

--- a/server/views/partials/stats.hbs
+++ b/server/views/partials/stats.hbs
@@ -82,7 +82,7 @@
           </svg>
         </div>
         <div>
-          <h2>Operation systems.</h2>
+          <h2>Operating systems.</h2>
           <canvas class="os" height="350" data-period="day" data-data="{{json stats.lastDay.stats.os}}"></canvas>
           <canvas class="os hidden" height="350" data-period="week" data-data="{{json stats.lastWeek.stats.os}}"></canvas>
           <canvas class="os hidden" height="350" data-period="month" data-data="{{json stats.lastMonth.stats.os}}"></canvas>

--- a/static/scripts/stats.js
+++ b/static/scripts/stats.js
@@ -310,7 +310,7 @@ function beautifyOsName(name) {
 }
 
 
-// create operation systems chart
+// create operating systems chart
 function createOsChart() {
   const canvases = document.querySelectorAll("canvas.os");
   if (!canvases || !canvases.length) return;


### PR DESCRIPTION
Caveats: Browsers do not let you pass passwords in http(s)://user:pass@host/link anymore, but this should be fine since #107 wants this feature for using kutt within tools and automated systems.

Feel free to ignore if we don't want to implement #107 