### PR TITLE
Add robots.txt to disallow all paths

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
I wanted to do this to prevent constant 404's from crawlers.

For my own hosted version, I absolutely want to deny all paths to robots. I'm not certain whether you also want that behaviour, or if there are some paths you wish to be crawled.

---

If the PR isn't acceptable, there is a workaround to add a robots.txt through your compose file:

```yaml
    volumes:
       - ./robots.txt:/kutt/static/robots.txt:ro
```