### PR TITLE
 fixing typo in the file server\views\partials\settings\change_passwo…

### DIFF
--- a/server/views/partials/settings/change_password.hbs
+++ b/server/views/partials/settings/change_password.hbs
@@ -12,7 +12,7 @@
   >
     <div class="inputs">
       <label class="{{#if errors.currentpassword}}error{{/if}}">
-        Current passwod:
+        Current password:
         <input 
           id="currentpassword" 
           name="currentpassword" 
@@ -23,7 +23,7 @@
         {{#if errors.currentpassword}}<p class="error">{{errors.currentpassword}}</p>{{/if}}
       </label>
       <label class="{{#if errors.newpassword}}error{{/if}}">
-        New passwod:
+        New password:
         <input 
           id="newpassword" 
           name="newpassword" 


### PR DESCRIPTION
Title:
Fix typo: "passwod" → "password"

Description:
This PR corrects a small typo where "passwod" was written instead of "password". This improves readability and avoids confusion.

Let me know if you need any changes! 🚀