### PR TITLE
fix: improve terms.hbs readability and fix typos

### DIFF
--- a/server/views/terms.hbs
+++ b/server/views/terms.hbs
@@ -3,8 +3,8 @@
   <h3>{{default_domain}} Terms of Service</h3>
   <p>
     By accessing the website at
-    <a href="https://{{default_domain}}">https://{{default_domain}}</a>, you are agreeing to be bound by these terms of service, all applicable
-    laws and regulations, and agree that you are responsible for compliance
+    <a href="https://{{default_domain}}">https://{{default_domain}}</a>, you agree to be bound by these terms of service, all applicable
+    laws and regulations, and acknowledge that you are responsible for compliance
     with any applicable local laws. If you do not agree with any of these
     terms, you are prohibited from using or accessing this site. The
     materials contained in this website are protected by applicable
@@ -14,7 +14,7 @@
     In no event shall {{site_name}} or its suppliers be
     liable for any damages (including, without limitation, damages for loss
     of data or profit, or due to business interruption) arising out of the
-    use or inability to use the materials on
+    use or inability to use the materials on the
     {{default_domain}} website, even if
     {{site_name}} or a {{site_name}}
     authorized representative has been notified orally or in writing of the
@@ -24,12 +24,12 @@
     you.
   </p>
   <p>
-    The materials appearing on {{site_name}} website could
+    The materials appearing on the {{site_name}} website may
     include technical, typographical, or photographic errors.
     {{site_name}} does not warrant that any of the
-    materials on its website are accurate, complete or current.
+    materials on its website are accurate, complete, or current.
     {{site_name}} may make changes to the materials
-    contained on its website at any time without notice. However
+    contained on its website at any time without notice. However,
     {{site_name}} does not make any commitment to update
     the materials.
   </p>
@@ -38,11 +38,11 @@
     to its website and is not responsible for the contents of any such
     linked site. The inclusion of any link does not imply endorsement by
     {{site_name}} of the site. Use of any such linked
-    website is at the "user's" own risk.
+    website is at the user's own risk.
   </p>
   <p>
     {{site_name}} may revise these terms of service for
-    its website at any time without notice. By using this website you are
+    its website at any time without notice. By using this website, you are
     agreeing to be bound by the then current version of these terms of
     service.
   </p>


### PR DESCRIPTION
## Description
This pull request improves the readability of the terms.hbs file and fixes several typos and inconsistencies.

### Changes made:
- Improved grammar and sentence structure
- Fixed inconsistent use of quotation marks
- Added missing articles and commas
- Made language more precise and professional
- Ensured consistent formatting throughout the document

### Examples of improvements:
- Changed "you are agreeing" to "you agree" for more direct language
- Changed "agree that you are responsible" to "acknowledge that you are responsible"
- Added "the" before website references for consistency
- Changed "could" to "may" for more precise language
- Added missing commas in lists and after introductory phrases
## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation