### PR TITLE
Fixing thestats

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "cookie-parser": "1.4.7",
         "cors": "2.8.5",
         "date-fns": "2.30.0",
-        "dotenv": "^16.4.7",
+        "dotenv": "16.4.7",
         "envalid": "8.0.0",
         "express": "4.21.2",
         "express-rate-limit": "7.5.0",

--- a/server/views/partials/stats.hbs
+++ b/server/views/partials/stats.hbs
@@ -11,12 +11,17 @@
 <div class="stats">
   <h2>
     <span class="label">Stats for:</span>
-    <a href="{{link.link.url}}" title="Short link">
+    <a href="{{link.link.url}}" title="Short link" target="_blank" rel="noopener">
       {{link.link.link}}
     </a>
   </h2>
   <div class="stats-body">
-    <p>Target: <span> <a>{{link.target}}</a></span></p>
+    <p>
+      <strong>Target:</strong>
+      <a href="{{link.target}}" target="_blank" rel="noopener">
+        {{link.target}}
+      </a>
+    </p>
   </div>
 </div>
 </div>

--- a/server/views/partials/stats.hbs
+++ b/server/views/partials/stats.hbs
@@ -8,15 +8,18 @@
     </div>
   </div>
 {{else}}
-  <div class="stats-info">
-    <h2>
-      Stats for:
-      <a href="{{link.link.url}}" title="Short link">
-        {{link.link.link}}
-      </a>
-    </h2>
-    <p>{{link.target}}</p>
+<div class="stats">
+  <h2>
+    <span class="label">Stats for:</span>
+    <a href="{{link.link.url}}" title="Short link">
+      {{link.link.link}}
+    </a>
+  </h2>
+  <div class="stats-body">
+    <p>Target: <span> <a>{{link.target}}</a></span></p>
   </div>
+</div>
+</div>
   <main id="stats">
     <div class="stats-head">
       <p>

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1852,17 +1852,27 @@ form#delete-account.htmx-request .spinner { display: block; }
   margin-right: 0.5rem;
 }
 
-.stats-info {
-  width: 100%;
+.stats {
   display: flex;
-  align-items: flex-end;
-  justify-content: space-between;
+  flex-direction: column;
+  max-width: 700px;
+  width: 100%;
 }
+.stats h2 {
+  font-size: 1.4rem;
+  font-weight: 600;
+  color: #2b2b2b;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin: 0;
+}
+.stats .label {white-space: nowrap;}
 
-.stats-info h2 { font-weight: 300; font-size: 24px; }
-.stats-info p { font-size: 14px; }
-.stats-info h2,
-.stats-info p { margin: 0 }
+.stats-body {font-size: 1.05rem;color: #444;}
+
+.stats-body span {font-weight: 500;}
 
 #stats {
   width: 100%;
@@ -1877,8 +1887,7 @@ form#delete-account.htmx-request .spinner { display: block; }
 }
 
 .stats-head {
-  width: 100%;
-  display: flex;
+  width: 100%; display: flex;
   align-items: center;
   background-color: var(--table-bg-color);
   justify-content: space-between;


### PR DESCRIPTION
This PR enhances the stats page by displaying the original (target) URL next to the short link. This provides users with more context and clarity about where their short URL redirects.

-Added clickable link to the target URL

-Opens in a new tab for better UX

-Minor HTML improvements for structure and accessibility
