### PR TITLE
Feature Request: Add Sorting by View Count in Admin Panel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "cookie-parser": "1.4.7",
         "cors": "2.8.5",
         "date-fns": "2.30.0",
-        "dotenv": "^16.4.7",
+        "dotenv": "16.4.7",
         "envalid": "8.0.0",
         "express": "4.21.2",
         "express-rate-limit": "7.5.0",

--- a/server/views/partials/admin/links/table.hbs
+++ b/server/views/partials/admin/links/table.hbs
@@ -15,9 +15,14 @@
     input changed delay:500ms from:[name='search'],
     input changed delay:500ms from:[name='user'],
     input changed delay:500ms from:[name='domain'],
+        input changed delay:500ms from:[name='sort_by'],
+
     input changed from:[name='banned'],
     input changed from:[name='anonymous'],
     input changed from:[name='has_domain'],
+    input changed from:[name='sort_by'],
+
+
   "
   hx-on:htmx:after-on-load="updateLinksNav();"
   hx-on:htmx:after-settle="onSearchInputLoad();"

--- a/server/views/partials/admin/links/thead.hbs
+++ b/server/views/partials/admin/links/thead.hbs
@@ -95,6 +95,19 @@
           <option value="true" {{#ifEquals query.has_domain 'true'}}selected{{/ifEquals}}>With domain</option>
           <option value="false" {{#ifEquals query.has_domain 'false'}}selected{{/ifEquals}}>No domain</option>
         </select>
+      <select 
+  id="sort_by"
+  name="sort_by"
+  class="table-input ban"
+  hx-on:change="resetTableNav()"
+>
+  <option value="" selected>sort...</option>
+  <option value="views_desc">Views ↓</option>
+  <option value="views_asc">Views ↑</option>
+  <option value="created_desc">Newest</option>
+  <option value="created_asc">Oldest</option>
+</select>
+
         <input id="total" name="total" type="hidden" value="{{total}}" />
         <input id="limit" name="limit" type="hidden" value="10" />
         <input id="skip" name="skip" type="hidden" value="0" />


### PR DESCRIPTION
Please consider adding an option in the admin panel of Kutt to sort the list of links by their view count. It would be helpful to have the ability to sort in both ascending and descending order.

Why this is useful:

Improved Link Monitoring: Admins would be able to quickly identify the most and least visited links, making it easier to track link performance.

Better Link Management: Sorting by view count will help identify unused links (if they have very few views) or overly used links (if they have exceptionally high views).

Enhanced User Experience: This feature would provide admins with more control over their data and improve the overall admin experience.

Thanks for considering this request!

https://github.com/user-attachments/assets/861f2a1c-1fd6-4c6f-b05d-2b379567450b




