### PR TITLE
adding the tittles for the icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "cookie-parser": "1.4.7",
         "cors": "2.8.5",
         "date-fns": "2.30.0",
-        "dotenv": "^16.4.7",
+        "dotenv": "16.4.7",
         "envalid": "8.0.0",
         "express": "4.21.2",
         "express-rate-limit": "7.5.0",

--- a/server/views/partials/admin/links/actions.hbs
+++ b/server/views/partials/admin/links/actions.hbs
@@ -1,31 +1,36 @@
 <td class="actions">
   {{#if password}}
-    <button class="action password" disabled="true" data-tooltip="Password protected">
+    <button class="action password" disabled="true" title="Password Protected" data-tooltip="Password protected">
       {{> icons/key}}
     </button>
   {{/if}}
+  
   {{#if banned}}
-    <button class="action banned" disabled="true" data-tooltip="Banned">
+    <button class="action banned" disabled="true" title="Banned" data-tooltip="Banned">
       {{> icons/stop}}
     </button>
   {{/if}}
+
   <a
     class="button action stats"
     href="/stats?id={{id}}"
-    title="Stats"
-    class="action stats"
+    title="View Stats"
   >
     {{> icons/chart}}
   </a>
+
   <button
     class="action qrcode"
+    title="Generate QR Code"
     hx-on:click="handleQRCode(this, 'admin-table-dialog')"
     data-url="{{link.url}}"
   >
     {{> icons/qrcode}}
   </button>
+
   <button 
     class="action edit"
+    title="Edit Link"
     hx-trigger="click queue:none"
     hx-ext="path-params"
     hx-get="/admin/link/edit/{id}" 
@@ -46,9 +51,11 @@
   >
     {{> icons/pencil}}
   </button>
+
   {{#unless banned}}
     <button 
       class="action ban" 
+      title="Ban Link"
       hx-on:click='openDialog("admin-table-dialog")' 
       hx-get="/confirm-link-ban" 
       hx-target="#admin-table-dialog .content-wrapper" 
@@ -58,8 +65,10 @@
       {{> icons/stop}}
     </button>
   {{/unless}}
+
   <button 
     class="action delete" 
+    title="Delete Link"
     hx-on:click='openDialog("admin-table-dialog")' 
     hx-get="/confirm-link-delete" 
     hx-target="#admin-table-dialog .content-wrapper" 

--- a/server/views/partials/links/actions.hbs
+++ b/server/views/partials/links/actions.hbs
@@ -1,31 +1,44 @@
 <td class="actions">
   {{#if password}}
-    <button class="action password" disabled="true" data-tooltip="Password protected">
+    <button 
+      class="action password" 
+      disabled 
+      title="Password Protected"
+    >
       {{> icons/key}}
     </button>
   {{/if}}
+  
   {{#if banned}}
-    <button class="action banned" disabled="true" data-tooltip="Banned">
+    <button 
+      class="action banned" 
+      disabled 
+      title="Banned"
+    >
       {{> icons/stop}}
     </button>
   {{/if}}
+
   <a
     class="button action stats"
     href="/stats?id={{id}}"
-    title="Stats"
-    class="action stats"
+    title="View Stats"
   >
     {{> icons/chart}}
   </a>
+
   <button
     class="action qrcode"
+    title="Show QR Code"
     hx-on:click="handleQRCode(this, 'link-dialog')"
     data-url="{{link.url}}"
   >
     {{> icons/qrcode}}
   </button>
+
   <button 
     class="action edit"
+    title="Edit Link"
     hx-trigger="click queue:none"
     hx-ext="path-params"
     hx-get="/link/edit/{id}" 
@@ -46,8 +59,10 @@
   >
     {{> icons/pencil}}
   </button>
+
   <button 
     class="action delete" 
+    title="Delete Link"
     hx-on:click='openDialog("link-dialog")' 
     hx-get="/confirm-link-delete" 
     hx-target="#link-dialog .content-wrapper" 


### PR DESCRIPTION
This pull request adds tooltips to the action buttons and links within the admin interface. The tooltips appear when the user hovers over the corresponding icon, providing additional context about the action each button performs. The changes improve the usability of the interface by making it clearer what each action does.
#885
