### PR TITLE
Fix typos in apikey.hbs and change_email.hbs

### DIFF
--- a/server/views/partials/settings/apikey.hbs
+++ b/server/views/partials/settings/apikey.hbs
@@ -1,7 +1,7 @@
 <section id="apikey-wrapper">
   <h2>API</h2>
   <p>
-    In additional to this website, you can use the API to create, delete and
+    In addition to this website, you can use the API to create, delete and
     get shortened URLs. If you're not familiar with API, don't generate the key. 
     DO NOT share this key on the client side of your website. 
     <a href="https://docs.kutt.it" title="API Docs" target="_blank">

--- a/server/views/partials/settings/change_email.hbs
+++ b/server/views/partials/settings/change_email.hbs
@@ -3,34 +3,18 @@
     Change email
   </h2>
   <p>Enter your password and a new email address to change your email address.</p>
-  <form 
-    id="change-email"
-    hx-post="/api/auth/change-email"
-    hx-select="form"
-    hx-swap="outerHTML"
-    hx-sync="this:abort"
-  >
+  <form id="change-email" hx-post="/api/auth/change-email" hx-select="form" hx-swap="outerHTML" hx-sync="this:abort">
     <div class="inputs">
       <label class="{{#if errors.password}}error{{/if}}">
-        Passwod:
-        <input 
-          id="password-for-change-email" 
-          name="password" 
-          type="password" 
-          placeholder="Password..."
-          hx-preserve="true"
-        />
+        Password:
+        <input id="password-for-change-email" name="password" type="password" placeholder="Password..."
+          hx-preserve="true" />
         {{#if errors.password}}<p class="error">{{errors.password}}</p>{{/if}}
       </label>
       <label class="{{#if errors.email}}error{{/if}}">
         New email address:
-        <input 
-          id="email-for-change-email" 
-          name="email" 
-          type="email" 
-          placeholder="john@example.com"
-          hx-preserve="true"
-        />
+        <input id="email-for-change-email" name="email" type="email" placeholder="john@example.com"
+          hx-preserve="true" />
         {{#if errors.email}}<p class="error">{{errors.email}}</p>{{/if}}
       </label>
     </div>
@@ -40,11 +24,11 @@
       Update
     </button>
     {{#if error}}
-      {{#unless errors}}
-        <p class="error">{{error}}</p>
-      {{/unless}}
+    {{#unless errors}}
+    <p class="error">{{error}}</p>
+    {{/unless}}
     {{else if success}}
-      <p class="success">{{success}}</p>
+    <p class="success">{{success}}</p>
     {{/if}}
   </form>
 </section>


### PR DESCRIPTION
Description:
This PR addresses two minor typographical errors in the UI files:

Corrected the typo 'additional' to 'in addition' in apikey.hbs

Fixed the typo 'passwod' to 'password' in change_email.hbs

These fixes improve the accuracy and readability of the text.

