### PR TITLE
Fix typo: 'in additional' -> 'in addition'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "cookie-parser": "1.4.7",
         "cors": "2.8.5",
         "date-fns": "2.30.0",
-        "dotenv": "^16.4.7",
+        "dotenv": "16.4.7",
         "envalid": "8.0.0",
         "express": "4.21.2",
         "express-rate-limit": "7.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "cookie-parser": "1.4.7",
         "cors": "2.8.5",
         "date-fns": "2.30.0",
-        "dotenv": "16.4.7",
+        "dotenv": "^16.4.7",
         "envalid": "8.0.0",
         "express": "4.21.2",
         "express-rate-limit": "7.5.0",

--- a/server/views/partials/settings/apikey.hbs
+++ b/server/views/partials/settings/apikey.hbs
@@ -1,7 +1,7 @@
 <section id="apikey-wrapper">
   <h2>API</h2>
   <p>
-    In additional to this website, you can use the API to create, delete and
+    In addition to this website, you can use the API to create, delete and
     get shortened URLs. If you're not familiar with API, don't generate the key. 
     DO NOT share this key on the client side of your website. 
     <a href="https://docs.kutt.it" title="API Docs" target="_blank">


### PR DESCRIPTION
This pull request fixes a small typo where "in additional" was used instead of "in addition".
In this update, I made only the necessary text correction without modifying any code formatting or structure.

This change aims to improve readability and clarity in the documentation/text, while keeping the rest of the codebase untouched — as per your previous feedback.