### PR TITLE
Feature Request: Add Sorting by View Count and Creation Date in Admin Panel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "cookie-parser": "1.4.7",
         "cors": "2.8.5",
         "date-fns": "2.30.0",
-        "dotenv": "^16.4.7",
+        "dotenv": "16.4.7",
         "envalid": "8.0.0",
         "express": "4.21.2",
         "express-rate-limit": "7.5.0",

--- a/server/queries/link.queries.js
+++ b/server/queries/link.queries.js
@@ -140,9 +140,13 @@ async function getAdmin(match, params) {
     query.andWhere(key, ...(Array.isArray(value) ? value : [value]));
   });
 
-  query
-    .orderBy("links.id", "desc")
-    .offset(params.skip)
+  let sortField = params?.sort || "id";
+  let sortDirection = params?.direction === "asc" ? "asc" : "desc";
+  const allowedFields = ["visit_count", "created_at"];
+  if (!allowedFields.includes(sortField)) sortField = "created_at";
+  query.orderBy(`links.${sortField}`, sortDirection);
+
+  query.offset(params.skip)
     .limit(params.limit)
   
   if (params?.user) {

--- a/server/utils/utils.js
+++ b/server/utils/utils.js
@@ -391,6 +391,13 @@ if (customCSSExists) {
 function getCustomCSSFileNames() {
   return custom_css_file_names;
 }
+hbs.registerHelper('eq', function(a, b) {
+  return a === b;
+});
+
+hbs.registerHelper('and', function(a, b) {
+  return a && b;
+});
 
 module.exports = {
   addProtocol,

--- a/server/views/partials/admin/links/thead.hbs
+++ b/server/views/partials/admin/links/thead.hbs
@@ -96,7 +96,7 @@
           <option value="false" {{#ifEquals query.has_domain 'false'}}selected{{/ifEquals}}>No domain</option>
         </select>
         <input id="total" name="total" type="hidden" value="{{total}}" />
-        <input id="limit" name="limit" type="hidden" value="10" />
+        <input id="limit" name="limit" type="hidden" value="{{query.limit}}" />
         <input id="skip" name="skip" type="hidden" value="0" />
       </div>
     </th>
@@ -104,9 +104,31 @@
   </tr>
   <tr>
     <th class="original-url">Original URL</th>
-    <th class="created-at">Created at</th>
+    <th class="created-at"
+        hx-get="/api/links/admin"
+        hx-include=".links-controls"
+        hx-params="not total"
+        hx-trigger="click"
+        hx-target="closest table"
+        hx-push-url="false"
+        hx-vals='{"sort": "created_at", "direction": "{{#if (eq sort "created_at")}}{{#if (eq direction "asc")}}desc{{else}}asc{{/if}}{{else}}asc{{/if}}"}'
+        style="cursor:pointer; user-select:none;">
+      Created at
+      {{#if (eq sort "created_at")}}<span>{{#if (eq direction "asc")}}▲{{else}}▼{{/if}}</span>{{/if}}
+    </th>
     <th class="short-link">Short link</th>
-    <th class="views">Views</th>
+    <th class="views"
+        hx-get="/api/links/admin"
+        hx-include=".links-controls"
+        hx-params="not total"
+        hx-trigger="click"
+        hx-target="closest table"
+        hx-push-url="false"
+        hx-vals='{"sort": "visit_count", "direction": "{{#if (eq sort "visit_count")}}{{#if (eq direction "asc")}}desc{{else}}asc{{/if}}{{else}}asc{{/if}}"}'
+        style="cursor:pointer; user-select:none;">
+      Views
+      {{#if (eq sort "visit_count")}}<span>{{#if (eq direction "asc")}}▲{{else}}▼{{/if}}</span>{{/if}}
+    </th>
     <th class="actions"></th>
   </tr>
 </thead>

--- a/server/views/partials/stats.hbs
+++ b/server/views/partials/stats.hbs
@@ -11,12 +11,17 @@
 <div class="stats">
   <h2>
     <span class="label">Stats for:</span>
-    <a href="{{link.link.url}}" title="Short link">
+    <a href="{{link.link.url}}" title="Short link" target="_blank" rel="noopener">
       {{link.link.link}}
     </a>
   </h2>
   <div class="stats-body">
-    <p>Target: <span> <a>{{link.target}}</a></span></p>
+    <p>
+      <strong>Target:</strong>
+      <a href="{{link.target}}" target="_blank" rel="noopener">
+        {{link.target}}
+      </a>
+    </p>
   </div>
 </div>
 </div>

--- a/server/views/partials/stats.hbs
+++ b/server/views/partials/stats.hbs
@@ -8,15 +8,18 @@
     </div>
   </div>
 {{else}}
-  <div class="stats-info">
-    <h2>
-      Stats for:
-      <a href="{{link.link.url}}" title="Short link">
-        {{link.link.link}}
-      </a>
-    </h2>
-    <p>{{link.target}}</p>
+<div class="stats">
+  <h2>
+    <span class="label">Stats for:</span>
+    <a href="{{link.link.url}}" title="Short link">
+      {{link.link.link}}
+    </a>
+  </h2>
+  <div class="stats-body">
+    <p>Target: <span> <a>{{link.target}}</a></span></p>
   </div>
+</div>
+</div>
   <main id="stats">
     <div class="stats-head">
       <p>

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1852,17 +1852,27 @@ form#delete-account.htmx-request .spinner { display: block; }
   margin-right: 0.5rem;
 }
 
-.stats-info {
-  width: 100%;
+.stats {
   display: flex;
-  align-items: flex-end;
-  justify-content: space-between;
+  flex-direction: column;
+  max-width: 700px;
+  width: 100%;
 }
+.stats h2 {
+  font-size: 1.4rem;
+  font-weight: 600;
+  color: #2b2b2b;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin: 0;
+}
+.stats .label {white-space: nowrap;}
 
-.stats-info h2 { font-weight: 300; font-size: 24px; }
-.stats-info p { font-size: 14px; }
-.stats-info h2,
-.stats-info p { margin: 0 }
+.stats-body {font-size: 1.05rem;color: #444;}
+
+.stats-body span {font-weight: 500;}
 
 #stats {
   width: 100%;
@@ -1877,8 +1887,7 @@ form#delete-account.htmx-request .spinner { display: block; }
 }
 
 .stats-head {
-  width: 100%;
-  display: flex;
+  width: 100%; display: flex;
   align-items: center;
   background-color: var(--table-bg-color);
   justify-content: space-between;


### PR DESCRIPTION
Hi @poeti8,

Thanks for the feedback on the previous PR!

I've now updated the implementation based on your comments:

-Sorting is now triggered by clicking on the column headers (not via a select input).

-The sorting logic is handled server-side, and the data is properly queried from the database.

-Supports sorting by both view count and creation date, in ascending and descending order.

Let me know if there’s anything else that needs adjustment. Appreciate your guidance!

#864
