### PR TITLE
Add `ADMIN_DOMAIN` and support for "global" domains

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -4,8 +4,12 @@ PORT=3000
 # Optional - The name of the site where Kutt is hosted
 SITE_NAME=Kutt
 
-# Optional - The domain that this website is on
+# Optional - The default domain for new links. This is also used as the admin domain if ADMIN_DOMAIN is not set
 DEFAULT_DOMAIN=localhost:3000
+
+# Optional - The domain where admin functions take place.
+# Falls back to DEFAULT_DOMAIN if unset.
+ADMIN_DOMAIN=
 
 # Required - A passphrase to encrypt JWT. Use a random long string
 JWT_SECRET=

--- a/server/env.js
+++ b/server/env.js
@@ -30,6 +30,7 @@ const spec = {
   PORT: num({ default: 3000 }),
   SITE_NAME: str({ example: "Kutt", default: "Kutt" }),
   DEFAULT_DOMAIN: str({ example: "kutt.it", default: "localhost:3000" }),
+  ADMIN_DOMAIN: str({ example: "admin.kutt.it", default: "" }),
   LINK_LENGTH: num({ default: 6 }),
   LINK_CUSTOM_ALPHABET: str({ default: "abcdefghkmnpqrstuvwxyzABCDEFGHKLMNPQRSTUVWXYZ23456789" }),
   TRUST_PROXY: bool({ default: true }),

--- a/server/handlers/links.handler.js
+++ b/server/handlers/links.handler.js
@@ -56,20 +56,20 @@ async function getAdmin(req, res) {
   const banned = utils.parseBooleanQuery(req.query.banned);
   const anonymous = utils.parseBooleanQuery(req.query.anonymous);
   const has_domain = utils.parseBooleanQuery(req.query.has_domain);
-  
+
   const match = {
     ...(banned !== undefined && { banned }),
     ...(anonymous !== undefined && { user_id: [anonymous ? "is" : "is not", null] }),
     ...(has_domain !== undefined && { domain_id: [has_domain ? "is not" : "is", null] }),
   };
-  
+
   // if domain is equal to the defualt domain,
   // it means admins is looking for links with the defualt domain (no custom user domain)
   if (domain === env.DEFAULT_DOMAIN) {
     domain = undefined;
     match.domain_id = null;
   }
-  
+
   const [data, total] = await Promise.all([
     query.link.getAdmin(match, { limit, search, user, domain, skip }),
     query.link.totalAdmin(match, { search, user, domain })
@@ -97,11 +97,12 @@ async function getAdmin(req, res) {
 };
 
 async function create(req, res) {
-  const { reuse, password, customurl, description, target, fetched_domain, expire_in } = req.body;
+  const { reuse, password, customurl, description, target, expire_in } = req.body;
+  const fetched_domain = req.body.fetched_domain || null;
   const domain_id = fetched_domain ? fetched_domain.id : null;
-  
+
   const targetDomain = utils.removeWww(URL.parse(target).hostname);
-  
+
   const tasks = await Promise.all([
     reuse &&
       query.link.find({
@@ -118,13 +119,13 @@ async function create(req, res) {
     validators.bannedDomain(targetDomain),
     validators.bannedHost(targetDomain)
   ]);
-  
+
   // if "reuse" is true, try to return
   // the existent URL without creating one
   if (tasks[0]) {
     return res.json(utils.sanitize.link(tasks[0]));
   }
-  
+
   // Check if custom link already exists
   if (tasks[1]) {
     const error = "Custom URL is already in use.";
@@ -145,16 +146,16 @@ async function create(req, res) {
   });
 
   link.domain = fetched_domain?.address;
-  
+
   if (req.isHTML) {
     res.setHeader("HX-Trigger", "reloadMainTable");
     const shortURL = utils.getShortURL(link.address, link.domain);
     return res.render("partials/shortener", {
-      link: shortURL.link, 
+      link: shortURL.link,
       url: shortURL.url,
     });
   }
-  
+
   return res
     .status(201)
     .send(utils.sanitize.link({ ...link }));
@@ -172,14 +173,14 @@ async function edit(req, res) {
 
   let isChanged = false;
   [
-    [req.body.address, "address"], 
-    [req.body.target, "target"], 
-    [req.body.description, "description"], 
-    [req.body.expire_in, "expire_in"], 
+    [req.body.address, "address"],
+    [req.body.target, "target"],
+    [req.body.description, "description"],
+    [req.body.expire_in, "expire_in"],
     [req.body.password, "password"]
   ].forEach(([value, name]) => {
     if (!value) {
-      if (name === "password" && link.password) 
+      if (name === "password" && link.password)
         req.body.password = null;
       else {
         delete req.body[name];
@@ -206,7 +207,7 @@ async function edit(req, res) {
   }
 
   const { address, target, description, expire_in, password } = req.body;
-  
+
   const targetDomain = target && utils.removeWww(URL.parse(target).hostname);
   const domain_id = link.domain_id || null;
 
@@ -265,14 +266,14 @@ async function editAdmin(req, res) {
 
   let isChanged = false;
   [
-    [req.body.address, "address"], 
-    [req.body.target, "target"], 
-    [req.body.description, "description"], 
-    [req.body.expire_in, "expire_in"], 
+    [req.body.address, "address"],
+    [req.body.target, "target"],
+    [req.body.description, "description"],
+    [req.body.expire_in, "expire_in"],
     [req.body.password, "password"]
   ].forEach(([value, name]) => {
     if (!value) {
-      if (name === "password" && link.password) 
+      if (name === "password" && link.password)
         req.body.password = null;
       else {
         delete req.body[name];
@@ -299,7 +300,7 @@ async function editAdmin(req, res) {
   }
 
   const { address, target, description, expire_in, password } = req.body;
-  
+
   const targetDomain = target && utils.removeWww(URL.parse(target).hostname);
   const domain_id = link.domain_id || null;
 
@@ -382,7 +383,7 @@ async function report(req, res) {
     });
     return;
   }
-  
+
   return res
     .status(200)
     .send({ message: "Thanks for the report, we'll take actions shortly." });
@@ -492,7 +493,7 @@ async function redirect(req, res, next) {
   const isRequestingInfo = /.*\+$/gi.test(req.params.id);
   if (isRequestingInfo && !link.password) {
     if (req.isHTML) {
-      res.render("url_info", { 
+      res.render("url_info", {
         title: "Short link information",
         target: link.target,
         link: utils.getShortURL(link.address, link.domain).link

--- a/server/handlers/renders.handler.js
+++ b/server/handlers/renders.handler.js
@@ -304,12 +304,23 @@ async function linkEditAdmin(req, res) {
   });
 }
 
+async function domainEditAdmin(req, res) {
+  const domain = await query.domain.find({ id: req.params.id });
+  if (!domain) {
+    throw new utils.CustomError("Could not find the domain.", 400);
+  }
+  res.render("partials/admin/domains/edit", {
+    ...utils.sanitize.domain_admin(domain),
+  });
+}
+
 module.exports = {
   addDomainAdmin,
   addDomainForm,
   admin,
   banned,
   confirmDomainBan,
+  domainEditAdmin,
   confirmDomainDelete,
   confirmDomainDeleteAdmin,
   confirmLinkBan,

--- a/server/mail/mail.js
+++ b/server/mail/mail.js
@@ -3,7 +3,8 @@ const path = require("node:path");
 const fs = require("node:fs");
 
 const { resetMailText, verifyMailText, changeEmailText } = require("./text");
-const { CustomError } = require("../utils");
+const utils = require("../utils");
+const { CustomError } = utils;
 const env = require("../env");
 
 const mailConfig = {
@@ -26,7 +27,7 @@ const verifyEmailTemplatePath = path.join(__dirname, "template-verify.html");
 const changeEmailTemplatePath = path.join(__dirname,"template-change-email.html");
 
 
-let resetEmailTemplate, 
+let resetEmailTemplate,
     verifyEmailTemplate,
     changeEmailTemplate;
 
@@ -34,15 +35,15 @@ let resetEmailTemplate,
 if (env.MAIL_ENABLED) {
   resetEmailTemplate = fs
     .readFileSync(resetEmailTemplatePath, { encoding: "utf-8" })
-    .replace(/{{domain}}/gm, env.DEFAULT_DOMAIN)
+    .replace(/{{domain}}/gm, utils.getAdminDomain())
     .replace(/{{site_name}}/gm, env.SITE_NAME);
   verifyEmailTemplate = fs
     .readFileSync(verifyEmailTemplatePath, { encoding: "utf-8" })
-    .replace(/{{domain}}/gm, env.DEFAULT_DOMAIN)
+    .replace(/{{domain}}/gm, utils.getAdminDomain())
     .replace(/{{site_name}}/gm, env.SITE_NAME);
   changeEmailTemplate = fs
     .readFileSync(changeEmailTemplatePath, { encoding: "utf-8" })
-    .replace(/{{domain}}/gm, env.DEFAULT_DOMAIN)
+    .replace(/{{domain}}/gm, utils.getAdminDomain())
     .replace(/{{site_name}}/gm, env.SITE_NAME);
 }
 
@@ -57,11 +58,11 @@ async function verification(user) {
     subject: "Verify your account",
     text: verifyMailText
       .replace(/{{verification}}/gim, user.verification_token)
-      .replace(/{{domain}}/gm, env.DEFAULT_DOMAIN)
+      .replace(/{{domain}}/gm, utils.getAdminDomain())
       .replace(/{{site_name}}/gm, env.SITE_NAME),
     html: verifyEmailTemplate
       .replace(/{{verification}}/gim, user.verification_token)
-      .replace(/{{domain}}/gm, env.DEFAULT_DOMAIN)
+      .replace(/{{domain}}/gm, utils.getAdminDomain())
       .replace(/{{site_name}}/gm, env.SITE_NAME)
   });
 
@@ -74,21 +75,21 @@ async function changeEmail(user) {
   if (!env.MAIL_ENABLED) {
     throw new Error("Attempting to send change email token but email is not enabled.");
   };
-  
+
   const mail = await transporter.sendMail({
     from: env.MAIL_FROM || env.MAIL_USER,
     to: user.change_email_address,
     subject: "Verify your new email address",
     text: changeEmailText
       .replace(/{{verification}}/gim, user.change_email_token)
-      .replace(/{{domain}}/gm, env.DEFAULT_DOMAIN)
+      .replace(/{{domain}}/gm, utils.getAdminDomain())
       .replace(/{{site_name}}/gm, env.SITE_NAME),
     html: changeEmailTemplate
       .replace(/{{verification}}/gim, user.change_email_token)
-      .replace(/{{domain}}/gm, env.DEFAULT_DOMAIN)
+      .replace(/{{domain}}/gm, utils.getAdminDomain())
       .replace(/{{site_name}}/gm, env.SITE_NAME)
   });
-  
+
   if (!mail.accepted.length) {
     throw new CustomError("Couldn't send verification email. Try again later.");
   }
@@ -105,10 +106,10 @@ async function resetPasswordToken(user) {
     subject: "Reset your password",
     text: resetMailText
       .replace(/{{resetpassword}}/gm, user.reset_password_token)
-      .replace(/{{domain}}/gm, env.DEFAULT_DOMAIN),
+      .replace(/{{domain}}/gm, utils.getAdminDomain()),
     html: resetEmailTemplate
       .replace(/{{resetpassword}}/gm, user.reset_password_token)
-      .replace(/{{domain}}/gm, env.DEFAULT_DOMAIN)
+      .replace(/{{domain}}/gm, utils.getAdminDomain())
   });
 
   if (!mail.accepted.length) {

--- a/server/migrations/20260223000000_add_is_global_to_domains.js
+++ b/server/migrations/20260223000000_add_is_global_to_domains.js
@@ -1,0 +1,22 @@
+async function up(knex) {
+  const hasColumn = await knex.schema.hasColumn("domains", "is_global");
+  if (!hasColumn) {
+    await knex.schema.alterTable("domains", table => {
+      table.boolean("is_global").notNullable().defaultTo(false);
+    });
+  }
+}
+
+async function down(knex) {
+  const hasColumn = await knex.schema.hasColumn("domains", "is_global");
+  if (hasColumn) {
+    await knex.schema.alterTable("domains", table => {
+      table.dropColumn("is_global");
+    });
+  }
+}
+
+module.exports = {
+  up,
+  down
+};

--- a/server/models/domain.model.js
+++ b/server/models/domain.model.js
@@ -30,8 +30,9 @@ async function createDomainTable(knex) {
         .uuid("uuid")
         .notNullable()
         .defaultTo(knex.fn.uuid());
+      table.boolean("is_global").notNullable().defaultTo(false);
       table.timestamps(false, true);
-      
+
     });
   }
 }

--- a/server/queries/domain.queries.js
+++ b/server/queries/domain.queries.js
@@ -35,7 +35,8 @@ async function add(params) {
     homepage: params.homepage,
     user_id: params.user_id,
     banned: !!params.banned,
-    banned_by_id: params.banned_by_id
+    banned_by_id: params.banned_by_id,
+    is_global: !!params.is_global
   };
 
   if (id) {
@@ -114,6 +115,7 @@ const selectable_admin = [
   "domains.address",
   "domains.homepage",
   "domains.banned",
+  "domains.is_global",
   "domains.created_at",
   "domains.updated_at",
   "domains.user_id",
@@ -140,11 +142,15 @@ async function getAdmin(match, params) {
     .groupBy("users.email");
 
   if (params?.user) {
-    const id = parseInt(params?.user);
-    if (Number.isNaN(id)) {
-      query[knex.compatibleILIKE]("users.email", "%" + params.user + "%");
+    if (params.user.toUpperCase() === "SYSTEM") {
+      query.whereNull("domains.user_id");
     } else {
-      query.andWhere("domains.user_id", id);
+      const id = parseInt(params?.user);
+      if (Number.isNaN(id)) {
+        query[knex.compatibleILIKE]("users.email", "%" + params.user + "%");
+      } else {
+        query.andWhere("domains.user_id", id);
+      }
     }
   }
 
@@ -178,11 +184,15 @@ async function totalAdmin(match, params) {
   });
   
   if (params?.user) {
-    const id = parseInt(params?.user);
-    if (Number.isNaN(id)) {
-      query[knex.compatibleILIKE]("users.email", "%" + params.user + "%");
+    if (params.user.toUpperCase() === "SYSTEM") {
+      query.whereNull("domains.user_id");
+    } else {
+      const id = parseInt(params?.user);
+      if (Number.isNaN(id)) {
+        query[knex.compatibleILIKE]("users.email", "%" + params.user + "%");
       } else {
-      query.andWhere("domains.user_id", id);
+        query.andWhere("domains.user_id", id);
+      }
     }
   }
 

--- a/server/routes/domain.routes.js
+++ b/server/routes/domain.routes.js
@@ -62,6 +62,17 @@ router.delete(
   asyncHandler(domains.removeAdmin)
 );
 
+router.patch(
+  "/admin/:id",
+  locals.viewTemplate("partials/admin/domains/edit"),
+  asyncHandler(auth.apikey),
+  asyncHandler(auth.jwt),
+  asyncHandler(auth.admin),
+  validators.updateDomainAdmin,
+  asyncHandler(helpers.verify),
+  asyncHandler(domains.updateAdmin)
+);
+
 router.post(
   "/admin/ban/:id",
   locals.viewTemplate("partials/admin/dialog/ban_domain"),

--- a/server/routes/renders.routes.js
+++ b/server/routes/renders.routes.js
@@ -203,8 +203,16 @@ router.get(
   "/admin/link/edit/:id",
   locals.noLayout,
   asyncHandler(auth.jwt),
-  asyncHandler(auth.admin), 
+  asyncHandler(auth.admin),
   asyncHandler(renders.linkEditAdmin)
+);
+
+router.get(
+  "/admin/domain/edit/:id",
+  locals.noLayout,
+  asyncHandler(auth.jwt),
+  asyncHandler(auth.admin),
+  asyncHandler(renders.domainEditAdmin)
 );
 
 router.get(

--- a/server/server.js
+++ b/server/server.js
@@ -16,7 +16,6 @@ const links = require("./handlers/links.handler");
 const routes = require("./routes");
 const utils = require("./utils");
 
-
 // run the cron jobs
 // the app might be running in cluster mode (multiple instances) so run the cron job only on one cluster (the first one)
 // NODE_APP_INSTANCE variable is added by pm2 automatically, if you're using something else to cluster your app, then make sure to set this variable
@@ -86,7 +85,7 @@ app.get("*", renders.notFound);
 
 // handle errors coming from above routes
 app.use(helpers.error);
-  
+
 app.listen(env.PORT, () => {
   console.log(`> Ready on http://localhost:${env.PORT}`);
 });

--- a/server/views/banned.hbs
+++ b/server/views/banned.hbs
@@ -1,11 +1,11 @@
 {{> header}}
 <section id="banned" class="section-container">
   <h2>
-    Link has been banned and removed because of 
+    Link has been banned and removed because of
     <span class="bold underline">malware or scam</span>.
   </h2>
   <h4>
-    If you noticed a malware/scam link shortened by {{default_domain}}, 
+    If you noticed a malware/scam link shortened by {{admin_domain}},
     <a href="/report" title="Send report">
       send us a report
     </a>.

--- a/server/views/partials/admin/dialog/add_domain.hbs
+++ b/server/views/partials/admin/dialog/add_domain.hbs
@@ -30,11 +30,20 @@
       {{#if errors.homepage}}<p class="error">{{errors.homepage}}</p>{{/if}}
     </label>
     <label class="checkbox">
-      <input 
-        id="add-domain-banned" 
+      <input
+        id="add-domain-global"
+        name="is_global"
+        type="checkbox"
+        hx-preserve="true"
+      />
+      Global
+    </label>
+    <label class="checkbox">
+      <input
+        id="add-domain-banned"
         name="banned"
         type="checkbox"
-        onchange="canSendVerificationEmail();" 
+        onchange="canSendVerificationEmail();"
         hx-preserve="true"
       />
       Banned

--- a/server/views/partials/admin/domains/actions.hbs
+++ b/server/views/partials/admin/domains/actions.hbs
@@ -5,25 +5,51 @@
     </button>
   {{/if}}
   {{#unless banned}}
-    <button 
-      class="action ban" 
-      hx-on:click='openDialog("admin-table-dialog")' 
-      hx-get="/confirm-domain-ban" 
-      hx-target="#admin-table-dialog .content-wrapper" 
-      hx-indicator="#admin-table-dialog" 
+    {{#unless is_protected}}
+      <button
+        class="action ban"
+        hx-on:click='openDialog("admin-table-dialog")'
+        hx-get="/confirm-domain-ban"
+        hx-target="#admin-table-dialog .content-wrapper"
+        hx-indicator="#admin-table-dialog"
+        hx-vals='{"id":"{{id}}"}'
+      >
+        {{> icons/stop}}
+      </button>
+    {{/unless}}
+  {{/unless}}
+  <button
+    class="action edit"
+    hx-trigger="click queue:none"
+    hx-get="/admin/domain/edit/{id}"
+    hx-ext="path-params"
+    hx-vals='{"id":"{{id}}"}'
+    hx-swap="beforeend"
+    hx-target="next tr.edit"
+    hx-indicator="next tr.edit"
+    hx-sync="this:drop"
+    hx-on::before-request="
+      const tr = event.detail.target;
+      tr.classList.add('show');
+      if (tr.querySelector('.content')) {
+        event.preventDefault();
+        tr.classList.remove('show');
+        tr.removeChild(tr.querySelector('.content'));
+      }
+    "
+  >
+    {{> icons/pencil}}
+  </button>
+  {{#unless is_protected}}
+    <button
+      class="action delete"
+      hx-on:click='openDialog("admin-table-dialog")'
+      hx-get="/confirm-domain-delete-admin"
+      hx-target="#admin-table-dialog .content-wrapper"
+      hx-indicator="#admin-table-dialog"
       hx-vals='{"id":"{{id}}"}'
     >
-      {{> icons/stop}}
+      {{> icons/trash}}
     </button>
   {{/unless}}
-  <button 
-    class="action delete" 
-    hx-on:click='openDialog("admin-table-dialog")' 
-    hx-get="/confirm-domain-delete-admin" 
-    hx-target="#admin-table-dialog .content-wrapper" 
-    hx-indicator="#admin-table-dialog" 
-    hx-vals='{"id":"{{id}}"}'
-  >
-    {{> icons/trash}}
-  </button>
 </td>

--- a/server/views/partials/admin/domains/edit.hbs
+++ b/server/views/partials/admin/domains/edit.hbs
@@ -1,0 +1,75 @@
+<td class="content">
+  {{#if id}}
+    <form
+      id="edit-domain-form-{{id}}"
+      hx-patch="/api/domains/admin/{id}"
+      hx-ext="path-params"
+      hx-vals='{"id":"{{id}}"}'
+      hx-select="form"
+      hx-swap="outerHTML"
+      hx-sync="this:replace"
+      class="{{class}}"
+    >
+      <div>
+        <label class="{{#if errors.homepage}}error{{/if}}">
+          Homepage:
+          <input
+            id="edit-homepage-{{id}}"
+            name="homepage"
+            type="text"
+            placeholder="https://example.com"
+            value="{{homepage}}"
+            hx-preserve="true"
+          />
+          {{#if errors.homepage}}<p class="error">{{errors.homepage}}</p>{{/if}}
+        </label>
+      </div>
+      {{#unless is_default}}
+        {{#unless is_admin}}
+          <label class="checkbox">
+            <input
+              id="edit-is-global-{{id}}"
+              name="is_global"
+              type="checkbox"
+              {{#if is_global}}checked{{/if}}
+            />
+            Global
+          </label>
+        {{/unless}}
+      {{/unless}}
+      <div>
+        <button
+          type="button"
+          onclick="
+            const tr = closest('tr');
+            if (!tr) return;
+            tr.classList.remove('show');
+            tr.removeChild(tr.querySelector('.content'));
+          "
+        >
+          Close
+        </button>
+        <button type="submit" class="primary">
+          <span class="reload">
+            {{> icons/reload}}
+          </span>
+          <span class="loader">
+            {{> icons/spinner}}
+          </span>
+          Update
+        </button>
+      </div>
+      <div class="response">
+        {{#if error}}
+          {{#unless errors}}
+            <p class="error">{{error}}</p>
+          {{/unless}}
+        {{else if success}}
+          <p class="success">{{success}}</p>
+        {{/if}}
+      </div>
+    </form>
+  {{else}}
+    <p class="no-data">No domain was found.</p>
+  {{/if}}
+</td>

--- a/server/views/partials/admin/domains/tr.hbs
+++ b/server/views/partials/admin/domains/tr.hbs
@@ -5,14 +5,13 @@
   <td class="domains-address right-fade">
     {{address}}
     <p class="description">
-      by&nbsp;
       {{~#if user_id~}}
-        <a 
-          aria-label="View user" 
-          data-tooltip="View user" 
+        by&nbsp;<a
+          aria-label="View user"
+          data-tooltip="View user"
           hx-get="/api/users/admin"
           hx-target="closest table"
-          hx-swap="outerHTML" 
+          hx-swap="outerHTML"
           hx-sync="this:replace"
           hx-indicator="closest table"
           hx-vals='{"search":"{{email}}"}'
@@ -23,12 +22,12 @@
         {{#ifEquals @root.query.user email}}
         {{else}}
           &nbsp;(
-          <a 
-            aria-label="View domains" 
-            data-tooltip="View domains" 
+          <a
+            aria-label="View domains"
+            data-tooltip="View domains"
             hx-get="/api/domains/admin"
             hx-target="closest table"
-            hx-swap="outerHTML" 
+            hx-swap="outerHTML"
             hx-sync="this:replace"
             hx-indicator="closest table"
             hx-vals='{"user":"{{email}}"}'
@@ -37,18 +36,20 @@
           </a>)
         {{/ifEquals}}
       {{~else~}}
-        <a 
-          aria-label="View system domains" 
-          data-tooltip="View system domains" 
+        {{#if is_default}}Default{{else}}{{#if is_admin}}Admin{{else}}Global{{/if}}{{/if}}
+        &nbsp;(
+        <a
+          aria-label="View system domains"
+          data-tooltip="View system domains"
           hx-get="/api/domains/admin"
           hx-target="closest table"
-          hx-swap="outerHTML" 
+          hx-swap="outerHTML"
           hx-sync="this:replace"
           hx-indicator="closest table"
-          hx-vals='{"owner":"false"}'
+          hx-vals='{"user":"SYSTEM"}'
         >
-          System
-        </a>
+          view domains
+        </a>)
       {{~/if~}}
       &nbsp;{{~#if description~}}· {{description}}{{~/if}}
     </p>

--- a/server/views/partials/report/form.hbs
+++ b/server/views/partials/report/form.hbs
@@ -3,21 +3,21 @@
   hx-post="/api/links/report"
   hx-sync="this:abort"
   hx-swap="outerHTML"
-> 
+>
   {{#if message}}
     <p class="success">{{message}}</p>
   {{else}}
     <div class="inputs-wrapper">
       <label>
         URL containing malware/scam:
-        <input 
-          type="text" 
-          id="link" 
-          name="link" 
-          placeholder="{{default_domain}}/example"
+        <input
+          type="text"
+          id="link"
+          name="link"
+          placeholder="{{admin_domain}}/example"
           hx-preserve="true"
           class="{{#if errors.link}}error{{/if}}"
-          required 
+          required
         />
       </label>
       <button type="submit" class="primary">

--- a/server/views/partials/shortener.hbs
+++ b/server/views/partials/shortener.hbs
@@ -2,19 +2,19 @@
   <div id="shorturl">
     {{#if link}}
       <div class="clipboard">
-        <button 
+        <button
           type="button"
-          aria-label="Copy" 
-          hx-on:click="handleShortURLCopyLink(this);" 
+          aria-label="Copy"
+          hx-on:click="handleShortURLCopyLink(this);"
           data-url="{{url}}"
         >
         {{> icons/copy}}
         </button>
         {{> icons/check}}
       </div>
-      <h1 
-        class="link" 
-        hx-on:click="handleShortURLCopyLink(this);" 
+      <h1
+        class="link"
+        hx-on:click="handleShortURLCopyLink(this);"
         data-url="{{url}}"
       >
         {{link}}
@@ -24,12 +24,12 @@
         <h1>Cut your links <span>shorter</span>.</h1>
     {{/unless}}
   </div>
-  <form 
-    id="shortener-form" 
-    hx-post="/api/links" 
-    hx-trigger="submit queue:none" 
-    hx-target="closest main" 
-    hx-swap="outerHTML" 
+  <form
+    id="shortener-form"
+    hx-post="/api/links"
+    hx-trigger="submit queue:none"
+    hx-target="closest main"
+    hx-swap="outerHTML"
     autocomplete="off"
   >
     <div class="target-wrapper {{#if errors.target}}error{{/if}}">
@@ -55,9 +55,9 @@
       {{/unless}}
     </div>
     <label id="advanced" class="checkbox">
-      <input 
-        name="show_advanced" 
-        type="checkbox" 
+      <input
+        name="show_advanced"
+        type="checkbox"
         hx-on:change="htmx.toggleClass('#advanced-options', 'hidden')"
         {{#if show_advanced}}checked="true"{{/if}}
       />
@@ -67,19 +67,22 @@
       <div class="advanced-input-wrapper">
         <label class="{{#if errors.domain}}error{{/if}}">
           Domain:
-          <select 
-            id="domain" 
-            name="domain" 
-            hx-preserve="true" 
+          <select
+            id="domain"
+            name="domain"
+            hx-preserve="true"
             hx-on:change="
               const elm = document.querySelector('#customurl-label span');
               if (!elm) return;
               elm.textContent = event.target.value + '/';
             "
           >
-            <option value={{default_domain}}>{{default_domain}}</option>
-            {{#each domains}}
-              <option value={{address}}>{{address}}</option>
+            <option value="{{default_domain}}">{{default_domain}} (default)</option>
+            {{#each other_global_domains}}
+              <option value="{{this}}">{{this}}</option>
+            {{/each}}
+            {{#each user_domains}}
+              <option value="{{address}}">{{address}}</option>
             {{/each}}
           </select>
           {{#if errors.domain}}<p class="error">{{errors.domain}}</p>{{/if}}
@@ -87,23 +90,23 @@
         <label id="customurl-label" class="{{#if errors.customurl}}error{{/if}}">
           <span id="customurl-label-value" hx-preserve="true">{{default_domain}}/</span>
           <input
-            type="text" 
-            id="customurl" 
-            name="customurl" 
-            placeholder="Custom address..." 
+            type="text"
+            id="customurl"
+            name="customurl"
+            placeholder="Custom address..."
             hx-preserve="true"
-            autocomplete="off" 
+            autocomplete="off"
           />
           {{#if errors.customurl}}<p class="error">{{errors.customurl}}</p>{{/if}}
         </label>
         <label class="{{#if errors.password}}error{{/if}}">
           Password:
-          <input 
-            type="password" 
-            id="password" 
-            name="password" 
-            placeholder="Password..." 
-            hx-preserve="true" 
+          <input
+            type="password"
+            id="password"
+            name="password"
+            placeholder="Password..."
+            hx-preserve="true"
             autocomplete="new-password"
           />
           {{#if errors.password}}<p class="error">{{errors.password}}</p>{{/if}}
@@ -112,23 +115,23 @@
       <div class="advanced-input-wrapper">
         <label class="expire-in {{#if errors.expire_in}}error{{/if}}">
           Expire in:
-          <input 
-            type="text" 
-            id="expire_in" 
-            name="expire_in" 
-            placeholder="2 minutes/hours/days" 
-            hx-preserve="true" 
+          <input
+            type="text"
+            id="expire_in"
+            name="expire_in"
+            placeholder="2 minutes/hours/days"
+            hx-preserve="true"
           />
           {{#if errors.expire_in}}<p class="error">{{errors.expire_in}}</p>{{/if}}
         </label>
         <label class="description {{#if errors.description}}error{{/if}}">
           Description:
-          <input 
-            type="text" 
-            id="description" 
-            name="description" 
-            placeholder="Description..." 
-            hx-preserve="true" 
+          <input
+            type="text"
+            id="description"
+            name="description"
+            placeholder="Description..."
+            hx-preserve="true"
           />
           {{#if errors.description}}<p class="error">{{errors.description}}</p>{{/if}}
         </label>

--- a/server/views/terms.hbs
+++ b/server/views/terms.hbs
@@ -1,9 +1,9 @@
 {{> header}}
 <section id="terms" class="section-container">
-  <h3>{{default_domain}} Terms of Service</h3>
+  <h3>{{admin_domain}} Terms of Service</h3>
   <p>
     By accessing the website at
-    <a href="https://{{default_domain}}">https://{{default_domain}}</a>, you are agreeing to be bound by these terms of service, all applicable
+    <a href="https://{{admin_domain}}">https://{{admin_domain}}</a>, you are agreeing to be bound by these terms of service, all applicable
     laws and regulations, and agree that you are responsible for compliance
     with any applicable local laws. If you do not agree with any of these
     terms, you are prohibited from using or accessing this site. The
@@ -15,7 +15,7 @@
     liable for any damages (including, without limitation, damages for loss
     of data or profit, or due to business interruption) arising out of the
     use or inability to use the materials on
-    {{default_domain}} website, even if
+    {{admin_domain}} website, even if
     {{site_name}} or a {{site_name}}
     authorized representative has been notified orally or in writing of the
     possibility of such damage. Because some jurisdictions do not allow

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1624,6 +1624,12 @@ table .short-link-wrapper { display: flex; align-items: center; }
   text-align: left;
 }
 
+#main-table-wrapper table tr.edit input[type="checkbox"] {
+  width: 1rem;
+  height: 1rem;
+  padding: 0;
+}
+
 #main-table-wrapper table tr.edit input[name="target"],
 #main-table-wrapper table tr.edit input[name="description"],
 #main-table-wrapper table tr.edit input[name="target"] + p,


### PR DESCRIPTION
This PR addresses a number of existing issues. I've tried to do so in a purely **additive**/**optional** way. Existing installations should not be impacted unless they change their configuration.

## "Admin" domain

 - Admin domain (`env.ADMIN_DOMAIN`) is added as an optional environment variable.
 - If set, it's the domain you use to access the admin dashboard through.
 - This allows you to run Kutt at a long url (e.g. `links.my-company.example.com`) while still using a short URL for links (e.g. `eg.url`), keeping the published links separate from the backend service

## "Global" domains
 - Admins can add one or more "global" domains.
 - Global domains are available to all users (but links must still be unique).
 - Addresses #861

## "Default" domain
 - With these changes, `env.DEFAULT_DOMAIN` can now live up to its name and be the default, without having to go into the "advanced" settings
 - Addresses #446

## Known issues

### Homepage/fallback redirect
The `DEFAULT_DOMAIN` does not support fallback redirects to a homepage. One possible solution would be to set it in the env also (e.g. `env.DEFAULT_HOMEPAGE`). Not yet implemented in this PR.

### Default domain not obvious when admin domain is set
The default domain is not listed on the Admin → Domains page. If the admin domain is set, it's not obvious what the default domain is. In this case, it might be worth appending it to the bottom of the domains table as a static entry or showing it somewhere else on that page?

P.S. Sorry for all the whitespace only changes. My editor automatically removes trailing whitespace whenever I edit a file