### PR TITLE
feat: make docker-compose use PORT env variable and .env file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,13 +2,15 @@ services:
   server:
     build:
       context: .
+    env_file:
+      - .env
     volumes:
        - db_data_sqlite:/var/lib/kutt
        - custom:/kutt/custom
     environment:
       DB_FILENAME: "/var/lib/kutt/data.sqlite"
     ports:
-      - 3000:3000
+      - ${PORT:-3000}:${PORT:-3000}
 volumes:
   db_data_sqlite:
   custom:


### PR DESCRIPTION
  ## Changes
   - Added `env_file: - .env` to load environment variables from .env file
   - Changed port mapping from hardcoded `3000:3000` to `${PORT:-3000}:${PORT:-3000}`
   - This allows users to customize the port via the PORT environment variable
   - Maintains backward compatibility with default port 3000

   ## Benefits
   - More flexible port configuration
   - Consistent with the existing PORT environment variable support
   - Follows Docker Compose best practices for environment variable usage