### PR TITLE
Return 404 status code for /404 page

### DIFF
--- a/server/handlers/renders.handler.js
+++ b/server/handlers/renders.handler.js
@@ -48,7 +48,7 @@ async function createAdmin(req, res) {
 }
 
 function notFound(req, res) {
-  res.render("404", {
+  res.status(404).render("404", {
     title: "404 - Not found"
   });
 }


### PR DESCRIPTION
I had an uptime check on one of my links and realized it wasn't failing because the 404 page returns a 200 http response.