### PR TITLE
Allow DB_SSL to be an object.

### DIFF
--- a/server/env.js
+++ b/server/env.js
@@ -1,5 +1,5 @@
 require("dotenv").config();
-const { cleanEnv, num, str, bool } = require("envalid");
+const { cleanEnv, num, str, bool, json } = require("envalid");
 const { readFileSync } = require("node:fs");
 
 const supportedDBClients = [
@@ -40,7 +40,7 @@ const spec = {
   DB_NAME: str({ default: "kutt" }),
   DB_USER: str({ default: "postgres" }),
   DB_PASSWORD: str({ default: "" }),
-  DB_SSL: bool({ default: false }),
+  DB_SSL: json({ default: false }),
   DB_POOL_MIN: num({ default: 0 }),
   DB_POOL_MAX: num({ default: 10 }),
   REDIS_ENABLED: bool({ default: false }),


### PR DESCRIPTION
Currently DB_SSL env var can only be assigned to a boolean value.
Some DB clients require that an object be provided or at least allow providing an object for deeper configuration of SSL.

For example, the mysql2 DB driver requires that an object be provided instead of a boolean:

DB_SSL: '{ "rejectUnauthorized": true }'

This change should still support providing simple boolean values like before.

