### PR TITLE
Add Prometheus metrics endpoint for HTTP observability

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -85,6 +85,12 @@ MAIL_PASSWORD=
 # Optional - Enable rate limitting for some API routes
 ENABLE_RATE_LIMIT=false
 
+# Optional - Enable metrics endpoint
+METRICS_ENABLED=true
+
+# Optional - Metrics endpoint path
+METRICS_PATH=/metrics
+
 # Optional - The email address that will receive submitted reports
 REPORT_EMAIL=
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ You can use files for each of the variables by appending `_FILE` to the name of 
 | `SERVER_CNAME_ADDRESS` | The subdomain shown to the user on the setting's page. It's only for display purposes and has no other use. | - | `custom.yoursite.com` |
 | `CUSTOM_DOMAIN_USE_HTTPS` | Use https for links with custom domain. It's on you to generate SSL certificates for those domains manually—at least on this version for now. | `false` | `true` |
 | `ENABLE_RATE_LIMIT` | Enable rate limiting for some API routes. If Redis is enabled uses Redis, otherwise, uses memory. | `false` | `true` |
+| `METRICS_ENABLED` | Enable the metrics endpoint. | `true` | `false` |
+| `METRICS_PATH` | Metrics endpoint path. | `/metrics` | `/internal/metrics` |
 | `MAIL_ENABLED` | Enable emails, which are used for signup, verifying or changing email address, resetting password, and sending reports. If is disabled, all these functionalities will be disabled too. | `false` | `true` | 
 | `MAIL_HOST` | Email server host | - | `your-mail-server.com` |
 | `MAIL_PORT` | Email server port | `587` | `465` (SSL) | 
@@ -137,6 +139,24 @@ You can use files for each of the variables by appending `_FILE` to the name of 
 | `OIDC_EMAIL_CLAIM` | Name of the field to get user's email from | `email` | `userEmail` | 
 | `REPORT_EMAIL` | The email address that will receive submitted reports | - | `example@yoursite.com` | 
 | `CONTACT_EMAIL` | The support email address to show on the app | - | `example@yoursite.com` | 
+
+## Metrics
+
+Kutt exposes a Prometheus text-format metrics endpoint for black-box monitoring. The payload includes response time statistics, throughput, in-flight requests, and success/error rates per HTTP status code.
+
+Default endpoint:
+
+```
+GET /metrics
+```
+
+Example Kubernetes annotations for Prometheus scraping:
+
+```
+prometheus.io/scrape: "true"
+prometheus.io/path: "/metrics"
+prometheus.io/port: "3000"
+```
 
 ## Themes and customizations
 
@@ -250,4 +270,3 @@ Download Kutt's extension for web browsers via below links.
 Pull requests are welcome. Open a discussion for feedback, requesting features, or discussing ideas.
 
 Special thanks to [Thomas](https://github.com/trgwii) and [Muthu](https://github.com/MKRhere). Logo design by [Muthu](https://github.com/MKRhere).
-

--- a/server/env.js
+++ b/server/env.js
@@ -69,6 +69,8 @@ const spec = {
   OIDC_SCOPE: str({ default: "openid profile email" }),
   OIDC_EMAIL_CLAIM: str({ default: "email" }),
   ENABLE_RATE_LIMIT: bool({ default: false }),
+  METRICS_ENABLED: bool({ default: true }),
+  METRICS_PATH: str({ default: "/metrics" }),
   REPORT_EMAIL: str({ default: "" }),
   CONTACT_EMAIL: str({ default: "" }),
   NODE_APP_INSTANCE: num({ default: 0 }),

--- a/server/utils/metrics.js
+++ b/server/utils/metrics.js
@@ -1,0 +1,351 @@
+const { performance } = require("node:perf_hooks");
+
+const latencyBucketsMs = [
+  5,
+  10,
+  25,
+  50,
+  100,
+  250,
+  500,
+  1000,
+  2500,
+  5000,
+  10000,
+];
+
+const state = {
+  processStartMs: Date.now(),
+  inFlight: 0,
+  totalRequests: 0,
+  totalDurationMs: 0,
+  minDurationMs: null,
+  maxDurationMs: 0,
+  lastDurationMs: 0,
+  statusCounts: new Map(),
+  bucketCounts: new Array(latencyBucketsMs.length + 1).fill(0),
+  successCount: 0,
+  errorCount: 0,
+};
+
+function observe(durationMs, statusCode) {
+  state.totalRequests += 1;
+  state.totalDurationMs += durationMs;
+  state.lastDurationMs = durationMs;
+
+  if (state.minDurationMs === null || durationMs < state.minDurationMs) {
+    state.minDurationMs = durationMs;
+  }
+
+  if (durationMs > state.maxDurationMs) {
+    state.maxDurationMs = durationMs;
+  }
+
+  if (statusCode >= 100 && statusCode < 400) {
+    state.successCount += 1;
+  } else if (statusCode >= 400) {
+    state.errorCount += 1;
+  }
+
+  const codeKey = String(statusCode || 0);
+  const current = state.statusCounts.get(codeKey) || {
+    count: 0,
+    totalDurationMs: 0,
+    minDurationMs: null,
+    maxDurationMs: 0,
+  };
+
+  current.count += 1;
+  current.totalDurationMs += durationMs;
+  if (current.minDurationMs === null || durationMs < current.minDurationMs) {
+    current.minDurationMs = durationMs;
+  }
+  if (durationMs > current.maxDurationMs) {
+    current.maxDurationMs = durationMs;
+  }
+  state.statusCounts.set(codeKey, current);
+
+  let bucketIndex = latencyBucketsMs.findIndex((limit) => durationMs <= limit);
+  if (bucketIndex === -1) {
+    bucketIndex = latencyBucketsMs.length;
+  }
+  state.bucketCounts[bucketIndex] += 1;
+}
+
+function percentileFromBuckets(percentile) {
+  if (state.totalRequests === 0) return 0;
+  const target = state.totalRequests * percentile;
+  let cumulative = 0;
+  for (let i = 0; i < state.bucketCounts.length; i += 1) {
+    cumulative += state.bucketCounts[i];
+    if (cumulative >= target) {
+      if (i >= latencyBucketsMs.length) {
+        return latencyBucketsMs[latencyBucketsMs.length - 1];
+      }
+      return latencyBucketsMs[i];
+    }
+  }
+  return latencyBucketsMs[latencyBucketsMs.length - 1];
+}
+
+function snapshot() {
+  const now = Date.now();
+  const uptimeSeconds = (now - state.processStartMs) / 1000;
+  const totalRequests = state.totalRequests;
+  const avgDurationMs = totalRequests ? state.totalDurationMs / totalRequests : 0;
+  const throughputRps = uptimeSeconds > 0 ? totalRequests / uptimeSeconds : 0;
+
+  const statusCodes = {};
+  const successRateByCode = {};
+  const errorRateByCode = {};
+
+  for (const [code, data] of state.statusCounts.entries()) {
+    const rate = totalRequests ? data.count / totalRequests : 0;
+    statusCodes[code] = {
+      count: data.count,
+      rate,
+      avg_response_time_ms: data.count ? data.totalDurationMs / data.count : 0,
+      min_response_time_ms: data.minDurationMs ?? 0,
+      max_response_time_ms: data.maxDurationMs,
+    };
+    const numericCode = Number(code);
+    if (numericCode >= 100 && numericCode < 400) {
+      successRateByCode[code] = rate;
+    } else if (numericCode >= 400) {
+      errorRateByCode[code] = rate;
+    }
+  }
+
+  const latencyBuckets = {};
+  latencyBucketsMs.forEach((limit, index) => {
+    latencyBuckets[`le_${limit}`] = state.bucketCounts[index];
+  });
+  latencyBuckets[`gt_${latencyBucketsMs[latencyBucketsMs.length - 1]}`] =
+    state.bucketCounts[state.bucketCounts.length - 1];
+
+  return {
+    timestamp: new Date(now).toISOString(),
+    uptime_seconds: uptimeSeconds,
+    in_flight: state.inFlight,
+    totals: {
+      requests: totalRequests,
+      success: state.successCount,
+      error: state.errorCount,
+    },
+    throughput_rps: throughputRps,
+    throughput_rpm: throughputRps * 60,
+    response_time_ms: {
+      avg: avgDurationMs,
+      min: state.minDurationMs ?? 0,
+      max: state.maxDurationMs,
+      p50: percentileFromBuckets(0.5),
+      p90: percentileFromBuckets(0.9),
+      p95: percentileFromBuckets(0.95),
+      last: state.lastDurationMs,
+    },
+    status_codes: statusCodes,
+    success_rate_by_code: successRateByCode,
+    error_rate_by_code: errorRateByCode,
+    latency_buckets_ms: latencyBuckets,
+  };
+}
+
+function middleware({ ignorePaths = [] } = {}) {
+  const ignored = new Set(ignorePaths);
+  return function metricsMiddleware(req, res, next) {
+    if (ignored.has(req.path)) {
+      next();
+      return;
+    }
+
+    const start = performance.now();
+    let finished = false;
+    state.inFlight += 1;
+
+    const done = () => {
+      if (finished) return;
+      finished = true;
+      state.inFlight = Math.max(0, state.inFlight - 1);
+      const durationMs = Math.max(0, performance.now() - start);
+      observe(durationMs, res.statusCode);
+    };
+
+    res.once("finish", done);
+    res.once("close", done);
+    next();
+  };
+}
+
+function prometheusText() {
+  const snap = snapshot();
+  const lines = [];
+
+  const push = (line) => {
+    lines.push(line);
+  };
+
+  const formatLabels = (labels) => {
+    const entries = Object.entries(labels);
+    if (entries.length === 0) return "";
+    const formatted = entries
+      .map(([key, value]) => `${key}="${String(value).replace(/"/g, '\\"')}"`)
+      .join(",");
+    return `{${formatted}}`;
+  };
+
+  const addMetric = (name, type, help, value, labels = {}) => {
+    if (help) push(`# HELP ${name} ${help}`);
+    if (type) push(`# TYPE ${name} ${type}`);
+    push(`${name}${formatLabels(labels)} ${value}`);
+  };
+
+  addMetric(
+    "http_requests_in_flight",
+    "gauge",
+    "Number of in-flight HTTP requests.",
+    snap.in_flight
+  );
+  addMetric(
+    "http_requests_total",
+    "counter",
+    "Total number of HTTP requests.",
+    snap.totals.requests
+  );
+  addMetric(
+    "http_requests_success_total",
+    "counter",
+    "Total number of successful HTTP requests (status < 400).",
+    snap.totals.success
+  );
+  addMetric(
+    "http_requests_error_total",
+    "counter",
+    "Total number of error HTTP requests (status >= 400).",
+    snap.totals.error
+  );
+  addMetric(
+    "http_requests_throughput_rps",
+    "gauge",
+    "HTTP requests per second since process start.",
+    snap.throughput_rps
+  );
+  addMetric(
+    "http_requests_throughput_rpm",
+    "gauge",
+    "HTTP requests per minute since process start.",
+    snap.throughput_rpm
+  );
+
+  push("# HELP http_request_duration_ms Request duration in milliseconds.");
+  push("# TYPE http_request_duration_ms histogram");
+  let cumulative = 0;
+  latencyBucketsMs.forEach((limit, index) => {
+    cumulative += state.bucketCounts[index];
+    push(
+      `http_request_duration_ms_bucket${formatLabels({ le: limit })} ${cumulative}`
+    );
+  });
+  push(
+    `http_request_duration_ms_bucket${formatLabels({
+      le: "+Inf",
+    })} ${snap.totals.requests}`
+  );
+  push(`http_request_duration_ms_sum ${state.totalDurationMs}`);
+  push(`http_request_duration_ms_count ${snap.totals.requests}`);
+
+  addMetric(
+    "http_response_time_ms_last",
+    "gauge",
+    "Last HTTP response time in milliseconds.",
+    snap.response_time_ms.last
+  );
+  addMetric(
+    "http_response_time_ms_min",
+    "gauge",
+    "Minimum HTTP response time in milliseconds.",
+    snap.response_time_ms.min
+  );
+  addMetric(
+    "http_response_time_ms_max",
+    "gauge",
+    "Maximum HTTP response time in milliseconds.",
+    snap.response_time_ms.max
+  );
+  addMetric(
+    "http_response_time_ms_avg",
+    "gauge",
+    "Average HTTP response time in milliseconds.",
+    snap.response_time_ms.avg
+  );
+  addMetric(
+    "http_response_time_ms_p50",
+    "gauge",
+    "50th percentile HTTP response time in milliseconds.",
+    snap.response_time_ms.p50
+  );
+  addMetric(
+    "http_response_time_ms_p90",
+    "gauge",
+    "90th percentile HTTP response time in milliseconds.",
+    snap.response_time_ms.p90
+  );
+  addMetric(
+    "http_response_time_ms_p95",
+    "gauge",
+    "95th percentile HTTP response time in milliseconds.",
+    snap.response_time_ms.p95
+  );
+
+  for (const [code, data] of Object.entries(snap.status_codes)) {
+    addMetric("http_requests_total", null, null, data.count, { code });
+    addMetric(
+      "http_request_duration_ms_avg",
+      "gauge",
+      "Average request duration by HTTP status code in milliseconds.",
+      data.avg_response_time_ms,
+      { code }
+    );
+    addMetric(
+      "http_request_duration_ms_min",
+      "gauge",
+      "Minimum request duration by HTTP status code in milliseconds.",
+      data.min_response_time_ms,
+      { code }
+    );
+    addMetric(
+      "http_request_duration_ms_max",
+      "gauge",
+      "Maximum request duration by HTTP status code in milliseconds.",
+      data.max_response_time_ms,
+      { code }
+    );
+  }
+
+  for (const [code, rate] of Object.entries(snap.success_rate_by_code)) {
+    addMetric(
+      "http_response_rate",
+      "gauge",
+      "Success or error rate per HTTP status code.",
+      rate,
+      { code, kind: "success" }
+    );
+  }
+
+  for (const [code, rate] of Object.entries(snap.error_rate_by_code)) {
+    addMetric(
+      "http_response_rate",
+      "gauge",
+      "Success or error rate per HTTP status code.",
+      rate,
+      { code, kind: "error" }
+    );
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+module.exports = {
+  middleware,
+  snapshot,
+  prometheusText,
+};


### PR DESCRIPTION
This PR adds a Prometheus scrape endpoint to improve black-box monitoring visibility for Kutt HTTP traffic.

### What changed
- Added a new `/metrics` endpoint (configurable via `METRICS_PATH`) that returns Prometheus text format.
- Added request metrics middleware to capture:
  - Request duration histogram (`http_server_requests_seconds`)
  - Request counters (total/success/error)
  - In-flight requests
  - Throughput gauges (RPS/RPM)
  - Per-status-code request counts and rate metrics
- Added new env vars:
  - `METRICS_ENABLED` (default: `true`)
  - `METRICS_PATH` (default: `/metrics`)
- Updated `.example.env` and README with metrics configuration and Kubernetes scrape annotation example.

### Why
This provides operational visibility for:
- Response time
- Throughput
- Error/success behavior by HTTP status code
- Prometheus-based scraping in Kubernetes environments

### Kubernetes scrape annotations example
```yaml
prometheus.io/scrape: "true"
prometheus.io/path: "/metrics"
prometheus.io/port: "3000"
```

### Notes
- Metrics are in-memory per app instance and reset on process restart.
- Suitable for per-pod scraping in Kubernetes.