### PR TITLE
fix(api): return 409 for duplicate custom URL conflicts

### DIFF
--- a/server/handlers/links.handler.js
+++ b/server/handlers/links.handler.js
@@ -129,7 +129,7 @@ async function create(req, res) {
   if (tasks[1]) {
     const error = "Custom URL is already in use.";
     res.locals.errors = { customurl: error };
-    throw new CustomError(error);
+    throw new CustomError(error, 409);
   }
 
   // Create new link
@@ -224,7 +224,7 @@ async function edit(req, res) {
   if (tasks[0]) {
     const error = "Custom URL is already in use.";
     res.locals.errors = { address: error };
-    throw new CustomError("Custom URL is already in use.");
+    throw new CustomError(error, 409);
   }
 
   // Update link
@@ -317,7 +317,7 @@ async function editAdmin(req, res) {
   if (tasks[0]) {
     const error = "Custom URL is already in use.";
     res.locals.errors = { address: error };
-    throw new CustomError("Custom URL is already in use.");
+    throw new CustomError(error, 409);
   }
 
   // Update link


### PR DESCRIPTION
Fixes #975

## Summary
When creating or updating a link with a `customurl`/`address` that already exists, the API currently throws `CustomError` without an explicit status code, which defaults to `500`.

This change returns `409 Conflict` for duplicate custom URL collisions, which matches HTTP semantics for resource conflicts and the expectation in #975.

## Changes
- `server/handlers/links.handler.js`
  - `create`: duplicate custom URL now throws `CustomError(error, 409)`
  - `edit`: duplicate custom URL now throws `CustomError(error, 409)`
  - `editAdmin`: duplicate custom URL now throws `CustomError(error, 409)`

## Verification
- `node --check server/handlers/links.handler.js`
