### PR TITLE
fix(db): avoid MySQL search collation mismatch in filters

### DIFF
--- a/server/knex.js
+++ b/server/knex.js
@@ -28,6 +28,6 @@ db.isPostgres = isPostgres;
 db.isSQLite = isSQLite;
 db.isMySQL = isMySQL;
 
-db.compatibleILIKE = isPostgres ? "andWhereILike" : "andWhereLike";
+db.compatibleILIKE = isPostgres || isMySQL ? "andWhereILike" : "andWhereLike";
 
 module.exports = db;


### PR DESCRIPTION
Fixes #945

## Problem
On MySQL with utf8mb4 collations, search filtering can fail with:

ER_COLLATION_CHARSET_MISMATCH: COLLATION 'utf8_bin' is not valid for CHARACTER SET 'utf8mb4'

The current compatibility selector routes MySQL search calls through andWhereLike, and Knex MySQL appends COLLATE utf8_bin for LIKE.

## Fix
Route MySQL through andWhereILike in the compatibility selector.

- before: Postgres -> andWhereILike, others -> andWhereLike
- after: Postgres/MySQL -> andWhereILike, others -> andWhereLike

This preserves all existing query call sites while avoiding the MySQL utf8_bin collation injection.

## File changed
- server/knex.js

## Verification
- node --check server/knex.js
