### PR TITLE
fix(validation): allow custom URLs with file extensions

### DIFF
--- a/server/utils/utils.js
+++ b/server/utils/utils.js
@@ -29,7 +29,7 @@ const charsNeedEscapeInRegExp = ".$*+?()[]{}|^-";
 const customAlphabetEscaped = env.LINK_CUSTOM_ALPHABET
   .split("").map(c => charsNeedEscapeInRegExp.includes(c) ? "\\" + c : c).join("");
 const customAlphabetRegex = new RegExp(`^[${customAlphabetEscaped}_-]+$`);
-const customAddressRegex = new RegExp("^[a-zA-Z0-9-_]+$");
+const customAddressRegex = new RegExp("^[a-zA-Z0-9-_.]+$");
 
 function isAdmin(user) {
   return user.role === ROLES.ADMIN;


### PR DESCRIPTION
## Summary
- Allow dots (`.`) in custom short URL slugs (e.g. `script.py`, `image.png`)
- Keep existing slug rules unchanged for other allowed characters

## Root cause
Custom slugs were validated by `customAddressRegex`, which only allowed `[a-zA-Z0-9-_]` and rejected dot-separated slugs.

## Changes
- `server/utils/utils.js`
  - `customAddressRegex` from `^[a-zA-Z0-9-_]+$` to `^[a-zA-Z0-9-_.]+$`

This validator is used by both create and edit link flows, so the fix applies consistently to both endpoints.

## Validation
- `node --check server/utils/utils.js`
- `node --check server/handlers/validators.handler.js`
- `node --check server/server.js`
- Regex sanity check:
  - `script.py` => valid
  - `image.png` => valid
  - `bad/slug` => invalid
  - `bad slug` => invalid

Closes #991
