### PR TITLE
Add UTM parameter support for shortened links

### DIFF
--- a/server/handlers/links.handler.js
+++ b/server/handlers/links.handler.js
@@ -16,6 +16,29 @@ const env = require("../env");
 const CustomError = utils.CustomError;
 const dnsLookup = promisify(dns.lookup);
 
+function buildTargetURL(link) {
+  const utmFields = [
+    ["utm_source", link.utm_source],
+    ["utm_medium", link.utm_medium],
+    ["utm_campaign", link.utm_campaign],
+    ["utm_term", link.utm_term],
+    ["utm_content", link.utm_content],
+  ];
+
+  const hasUTM = utmFields.some(([, v]) => v);
+  if (!hasUTM) return link.target;
+
+  try {
+    const url = new globalThis.URL(link.target);
+    utmFields.forEach(([key, value]) => {
+      if (value) url.searchParams.set(key, value);
+    });
+    return url.toString();
+  } catch {
+    return link.target;
+  }
+}
+
 async function get(req, res) {
   const { limit, skip } = req.context;
   const search = req.query.search;
@@ -97,7 +120,8 @@ async function getAdmin(req, res) {
 };
 
 async function create(req, res) {
-  const { reuse, password, customurl, description, target, fetched_domain, expire_in } = req.body;
+  const { reuse, password, customurl, description, target, fetched_domain, expire_in,
+          utm_source, utm_medium, utm_campaign, utm_term, utm_content } = req.body;
   const domain_id = fetched_domain ? fetched_domain.id : null;
   
   const targetDomain = utils.removeWww(URL.parse(target).hostname);
@@ -141,7 +165,12 @@ async function create(req, res) {
     description,
     target,
     expire_in,
-    user_id: req.user && req.user.id
+    user_id: req.user && req.user.id,
+    utm_source,
+    utm_medium,
+    utm_campaign,
+    utm_term,
+    utm_content,
   });
 
   link.domain = fetched_domain?.address;
@@ -172,14 +201,19 @@ async function edit(req, res) {
 
   let isChanged = false;
   [
-    [req.body.address, "address"], 
-    [req.body.target, "target"], 
-    [req.body.description, "description"], 
-    [req.body.expire_in, "expire_in"], 
-    [req.body.password, "password"]
+    [req.body.address, "address"],
+    [req.body.target, "target"],
+    [req.body.description, "description"],
+    [req.body.expire_in, "expire_in"],
+    [req.body.password, "password"],
+    [req.body.utm_source, "utm_source"],
+    [req.body.utm_medium, "utm_medium"],
+    [req.body.utm_campaign, "utm_campaign"],
+    [req.body.utm_term, "utm_term"],
+    [req.body.utm_content, "utm_content"],
   ].forEach(([value, name]) => {
     if (!value) {
-      if (name === "password" && link.password) 
+      if (name === "password" && link.password)
         req.body.password = null;
       else {
         delete req.body[name];
@@ -205,8 +239,9 @@ async function edit(req, res) {
     throw new CustomError("Should at least update one field.");
   }
 
-  const { address, target, description, expire_in, password } = req.body;
-  
+  const { address, target, description, expire_in, password,
+          utm_source, utm_medium, utm_campaign, utm_term, utm_content } = req.body;
+
   const targetDomain = target && utils.removeWww(URL.parse(target).hostname);
   const domain_id = link.domain_id || null;
 
@@ -237,7 +272,12 @@ async function edit(req, res) {
       ...(description && { description }),
       ...(target && { target }),
       ...(expire_in && { expire_in }),
-      ...((password || password === null) && { password })
+      ...((password || password === null) && { password }),
+      ...(utm_source !== undefined && { utm_source: utm_source || null }),
+      ...(utm_medium !== undefined && { utm_medium: utm_medium || null }),
+      ...(utm_campaign !== undefined && { utm_campaign: utm_campaign || null }),
+      ...(utm_term !== undefined && { utm_term: utm_term || null }),
+      ...(utm_content !== undefined && { utm_content: utm_content || null }),
     }
   );
 
@@ -265,14 +305,19 @@ async function editAdmin(req, res) {
 
   let isChanged = false;
   [
-    [req.body.address, "address"], 
-    [req.body.target, "target"], 
-    [req.body.description, "description"], 
-    [req.body.expire_in, "expire_in"], 
-    [req.body.password, "password"]
+    [req.body.address, "address"],
+    [req.body.target, "target"],
+    [req.body.description, "description"],
+    [req.body.expire_in, "expire_in"],
+    [req.body.password, "password"],
+    [req.body.utm_source, "utm_source"],
+    [req.body.utm_medium, "utm_medium"],
+    [req.body.utm_campaign, "utm_campaign"],
+    [req.body.utm_term, "utm_term"],
+    [req.body.utm_content, "utm_content"],
   ].forEach(([value, name]) => {
     if (!value) {
-      if (name === "password" && link.password) 
+      if (name === "password" && link.password)
         req.body.password = null;
       else {
         delete req.body[name];
@@ -298,8 +343,9 @@ async function editAdmin(req, res) {
     throw new CustomError("Should at least update one field.");
   }
 
-  const { address, target, description, expire_in, password } = req.body;
-  
+  const { address, target, description, expire_in, password,
+          utm_source, utm_medium, utm_campaign, utm_term, utm_content } = req.body;
+
   const targetDomain = target && utils.removeWww(URL.parse(target).hostname);
   const domain_id = link.domain_id || null;
 
@@ -330,7 +376,12 @@ async function editAdmin(req, res) {
       ...(description && { description }),
       ...(target && { target }),
       ...(expire_in && { expire_in }),
-      ...((password || password === null) && { password })
+      ...((password || password === null) && { password }),
+      ...(utm_source !== undefined && { utm_source: utm_source || null }),
+      ...(utm_medium !== undefined && { utm_medium: utm_medium || null }),
+      ...(utm_campaign !== undefined && { utm_campaign: utm_campaign || null }),
+      ...(utm_term !== undefined && { utm_term: utm_term || null }),
+      ...(utm_content !== undefined && { utm_content: utm_content || null }),
     }
   );
 
@@ -516,7 +567,7 @@ async function redirect(req, res, next) {
           if (colon !== -1) {
             const password = decoded.slice(colon + 1);
             const matches = await bcrypt.compare(password, link.password);
-            if (matches) return res.redirect(link.target);
+            if (matches) return res.redirect(buildTargetURL(link));
           }
         }
       }
@@ -541,7 +592,7 @@ async function redirect(req, res, next) {
   }
 
   // 8. Redirect to target
-  return res.redirect(link.target);
+  return res.redirect(buildTargetURL(link));
 };
 
 async function redirectProtected(req, res) {
@@ -574,14 +625,14 @@ async function redirectProtected(req, res) {
 
   // 5. Send target
   if (req.isHTML) {
-    res.setHeader("HX-Redirect", link.target);
+    res.setHeader("HX-Redirect", buildTargetURL(link));
     res.render("partials/protected/form", {
       id: link.uuid,
       message: "Redirecting...",
     });
     return;
   }
-  return res.status(200).send({ target: link.target });
+  return res.status(200).send({ target: buildTargetURL(link) });
 };
 
 async function redirectCustomDomainHomepage(req, res, next) {

--- a/server/handlers/validators.handler.js
+++ b/server/handlers/validators.handler.js
@@ -94,7 +94,37 @@ const createLink = [
 
       if (!domain) return Promise.reject();
     })
-    .withMessage("You can't use this domain.")
+    .withMessage("You can't use this domain."),
+  body("utm_source")
+    .optional({ nullable: true, checkFalsy: true })
+    .isString()
+    .trim()
+    .isLength({ min: 1, max: 255 })
+    .withMessage("UTM Source length must be between 1 and 255."),
+  body("utm_medium")
+    .optional({ nullable: true, checkFalsy: true })
+    .isString()
+    .trim()
+    .isLength({ min: 1, max: 255 })
+    .withMessage("UTM Medium length must be between 1 and 255."),
+  body("utm_campaign")
+    .optional({ nullable: true, checkFalsy: true })
+    .isString()
+    .trim()
+    .isLength({ min: 1, max: 255 })
+    .withMessage("UTM Campaign length must be between 1 and 255."),
+  body("utm_term")
+    .optional({ nullable: true, checkFalsy: true })
+    .isString()
+    .trim()
+    .isLength({ min: 1, max: 255 })
+    .withMessage("UTM Term length must be between 1 and 255."),
+  body("utm_content")
+    .optional({ nullable: true, checkFalsy: true })
+    .isString()
+    .trim()
+    .isLength({ min: 1, max: 255 })
+    .withMessage("UTM Content length must be between 1 and 255."),
 ];
 
 const editLink = [
@@ -146,6 +176,36 @@ const editLink = [
     .trim()
     .isLength({ min: 0, max: 2040 })
     .withMessage("Description length must be between 0 and 2040."),
+  body("utm_source")
+    .optional({ nullable: true, checkFalsy: true })
+    .isString()
+    .trim()
+    .isLength({ min: 1, max: 255 })
+    .withMessage("UTM Source length must be between 1 and 255."),
+  body("utm_medium")
+    .optional({ nullable: true, checkFalsy: true })
+    .isString()
+    .trim()
+    .isLength({ min: 1, max: 255 })
+    .withMessage("UTM Medium length must be between 1 and 255."),
+  body("utm_campaign")
+    .optional({ nullable: true, checkFalsy: true })
+    .isString()
+    .trim()
+    .isLength({ min: 1, max: 255 })
+    .withMessage("UTM Campaign length must be between 1 and 255."),
+  body("utm_term")
+    .optional({ nullable: true, checkFalsy: true })
+    .isString()
+    .trim()
+    .isLength({ min: 1, max: 255 })
+    .withMessage("UTM Term length must be between 1 and 255."),
+  body("utm_content")
+    .optional({ nullable: true, checkFalsy: true })
+    .isString()
+    .trim()
+    .isLength({ min: 1, max: 255 })
+    .withMessage("UTM Content length must be between 1 and 255."),
   param("id", "ID is invalid.")
     .exists({ checkFalsy: true, checkNull: true })
     .isLength({ min: 36, max: 36 })

--- a/server/migrations/20260325180240_utm_params.js
+++ b/server/migrations/20260325180240_utm_params.js
@@ -12,13 +12,16 @@ async function up(knex) {
 }
 
 async function down(knex) {
-  await knex.schema.alterTable("links", table => {
-    table.dropColumn("utm_source");
-    table.dropColumn("utm_medium");
-    table.dropColumn("utm_campaign");
-    table.dropColumn("utm_term");
-    table.dropColumn("utm_content");
-  });
+  const hasUtmSource = await knex.schema.hasColumn("links", "utm_source");
+  if (hasUtmSource) {
+    await knex.schema.alterTable("links", table => {
+      table.dropColumn("utm_source");
+      table.dropColumn("utm_medium");
+      table.dropColumn("utm_campaign");
+      table.dropColumn("utm_term");
+      table.dropColumn("utm_content");
+    });
+  }
 }
 
 module.exports = {

--- a/server/migrations/20260325180240_utm_params.js
+++ b/server/migrations/20260325180240_utm_params.js
@@ -1,0 +1,27 @@
+async function up(knex) {
+  const hasUtmSource = await knex.schema.hasColumn("links", "utm_source");
+  if (!hasUtmSource) {
+    await knex.schema.alterTable("links", table => {
+      table.string("utm_source");
+      table.string("utm_medium");
+      table.string("utm_campaign");
+      table.string("utm_term");
+      table.string("utm_content");
+    });
+  }
+}
+
+async function down(knex) {
+  await knex.schema.alterTable("links", table => {
+    table.dropColumn("utm_source");
+    table.dropColumn("utm_medium");
+    table.dropColumn("utm_campaign");
+    table.dropColumn("utm_term");
+    table.dropColumn("utm_content");
+  });
+}
+
+module.exports = {
+  up,
+  down
+}

--- a/server/queries/link.queries.js
+++ b/server/queries/link.queries.js
@@ -21,6 +21,11 @@ const selectable = [
   "links.visit_count",
   "links.user_id",
   "links.uuid",
+  "links.utm_source",
+  "links.utm_medium",
+  "links.utm_campaign",
+  "links.utm_term",
+  "links.utm_content",
   "domains.address as domain"
 ];
 
@@ -215,7 +220,12 @@ async function create(params) {
       address: params.address,
       description: params.description || null,
       expire_in: params.expire_in || null,
-      target: params.target
+      target: params.target,
+      utm_source: params.utm_source || null,
+      utm_medium: params.utm_medium || null,
+      utm_campaign: params.utm_campaign || null,
+      utm_term: params.utm_term || null,
+      utm_content: params.utm_content || null,
     },
     "*"
   );

--- a/server/views/partials/admin/links/edit.hbs
+++ b/server/views/partials/admin/links/edit.hbs
@@ -77,7 +77,51 @@
         </label>
       </div>
       <div>
-        <button 
+        <label class="{{#if errors.utm_source}}error{{/if}}">
+          UTM Source:
+          <input
+            id="edit-utm_source-{{id}}"
+            name="utm_source" type="text" placeholder="e.g. google"
+            value="{{utm_source}}" hx-preserve="true" />
+          {{#if errors.utm_source}}<p class="error">{{errors.utm_source}}</p>{{/if}}
+        </label>
+        <label class="{{#if errors.utm_medium}}error{{/if}}">
+          UTM Medium:
+          <input
+            id="edit-utm_medium-{{id}}"
+            name="utm_medium" type="text" placeholder="e.g. cpc"
+            value="{{utm_medium}}" hx-preserve="true" />
+          {{#if errors.utm_medium}}<p class="error">{{errors.utm_medium}}</p>{{/if}}
+        </label>
+        <label class="{{#if errors.utm_campaign}}error{{/if}}">
+          UTM Campaign:
+          <input
+            id="edit-utm_campaign-{{id}}"
+            name="utm_campaign" type="text" placeholder="e.g. spring_sale"
+            value="{{utm_campaign}}" hx-preserve="true" />
+          {{#if errors.utm_campaign}}<p class="error">{{errors.utm_campaign}}</p>{{/if}}
+        </label>
+      </div>
+      <div>
+        <label class="{{#if errors.utm_term}}error{{/if}}">
+          UTM Term:
+          <input
+            id="edit-utm_term-{{id}}"
+            name="utm_term" type="text" placeholder="e.g. running+shoes"
+            value="{{utm_term}}" hx-preserve="true" />
+          {{#if errors.utm_term}}<p class="error">{{errors.utm_term}}</p>{{/if}}
+        </label>
+        <label class="{{#if errors.utm_content}}error{{/if}}">
+          UTM Content:
+          <input
+            id="edit-utm_content-{{id}}"
+            name="utm_content" type="text" placeholder="e.g. logolink"
+            value="{{utm_content}}" hx-preserve="true" />
+          {{#if errors.utm_content}}<p class="error">{{errors.utm_content}}</p>{{/if}}
+        </label>
+      </div>
+      <div>
+        <button
           type="button"
           onclick="
             const tr = closest('tr');

--- a/server/views/partials/links/edit.hbs
+++ b/server/views/partials/links/edit.hbs
@@ -77,7 +77,51 @@
         </label>
       </div>
       <div>
-        <button 
+        <label class="{{#if errors.utm_source}}error{{/if}}">
+          UTM Source:
+          <input
+            id="edit-utm_source-{{id}}"
+            name="utm_source" type="text" placeholder="e.g. google"
+            value="{{utm_source}}" hx-preserve="true" />
+          {{#if errors.utm_source}}<p class="error">{{errors.utm_source}}</p>{{/if}}
+        </label>
+        <label class="{{#if errors.utm_medium}}error{{/if}}">
+          UTM Medium:
+          <input
+            id="edit-utm_medium-{{id}}"
+            name="utm_medium" type="text" placeholder="e.g. cpc"
+            value="{{utm_medium}}" hx-preserve="true" />
+          {{#if errors.utm_medium}}<p class="error">{{errors.utm_medium}}</p>{{/if}}
+        </label>
+        <label class="{{#if errors.utm_campaign}}error{{/if}}">
+          UTM Campaign:
+          <input
+            id="edit-utm_campaign-{{id}}"
+            name="utm_campaign" type="text" placeholder="e.g. spring_sale"
+            value="{{utm_campaign}}" hx-preserve="true" />
+          {{#if errors.utm_campaign}}<p class="error">{{errors.utm_campaign}}</p>{{/if}}
+        </label>
+      </div>
+      <div>
+        <label class="{{#if errors.utm_term}}error{{/if}}">
+          UTM Term:
+          <input
+            id="edit-utm_term-{{id}}"
+            name="utm_term" type="text" placeholder="e.g. running+shoes"
+            value="{{utm_term}}" hx-preserve="true" />
+          {{#if errors.utm_term}}<p class="error">{{errors.utm_term}}</p>{{/if}}
+        </label>
+        <label class="{{#if errors.utm_content}}error{{/if}}">
+          UTM Content:
+          <input
+            id="edit-utm_content-{{id}}"
+            name="utm_content" type="text" placeholder="e.g. logolink"
+            value="{{utm_content}}" hx-preserve="true" />
+          {{#if errors.utm_content}}<p class="error">{{errors.utm_content}}</p>{{/if}}
+        </label>
+      </div>
+      <div>
+        <button
           type="button"
           onclick="
             const tr = closest('tr');

--- a/server/views/partials/shortener.hbs
+++ b/server/views/partials/shortener.hbs
@@ -133,6 +133,35 @@
           {{#if errors.description}}<p class="error">{{errors.description}}</p>{{/if}}
         </label>
       </div>
+      <div class="advanced-input-wrapper">
+        <label class="{{#if errors.utm_source}}error{{/if}}">
+          UTM Source:
+          <input type="text" id="utm_source" name="utm_source" placeholder="e.g. google" hx-preserve="true" />
+          {{#if errors.utm_source}}<p class="error">{{errors.utm_source}}</p>{{/if}}
+        </label>
+        <label class="{{#if errors.utm_medium}}error{{/if}}">
+          UTM Medium:
+          <input type="text" id="utm_medium" name="utm_medium" placeholder="e.g. cpc" hx-preserve="true" />
+          {{#if errors.utm_medium}}<p class="error">{{errors.utm_medium}}</p>{{/if}}
+        </label>
+        <label class="{{#if errors.utm_campaign}}error{{/if}}">
+          UTM Campaign:
+          <input type="text" id="utm_campaign" name="utm_campaign" placeholder="e.g. spring_sale" hx-preserve="true" />
+          {{#if errors.utm_campaign}}<p class="error">{{errors.utm_campaign}}</p>{{/if}}
+        </label>
+      </div>
+      <div class="advanced-input-wrapper">
+        <label class="{{#if errors.utm_term}}error{{/if}}">
+          UTM Term:
+          <input type="text" id="utm_term" name="utm_term" placeholder="e.g. running+shoes" hx-preserve="true" />
+          {{#if errors.utm_term}}<p class="error">{{errors.utm_term}}</p>{{/if}}
+        </label>
+        <label class="{{#if errors.utm_content}}error{{/if}}">
+          UTM Content:
+          <input type="text" id="utm_content" name="utm_content" placeholder="e.g. logolink" hx-preserve="true" />
+          {{#if errors.utm_content}}<p class="error">{{errors.utm_content}}</p>{{/if}}
+        </label>
+      </div>
     </section>
   </form>
 </main>


### PR DESCRIPTION
- Links can now carry UTM parameters (source, medium, campaign, term, content). On redirect, `buildTargetURL()` appends them to the target URL.
- Migration adds five nullable string columns to `links`.
- All UTM fields are validated as strings, max 255 chars.
- New input fields in the shortener form and both edit dialogs (user + admin).

<img width="938" height="620" alt="image" src="https://github.com/user-attachments/assets/b0d3a016-fb14-4bf9-81a8-77a499c5cfcc" />
