### PR TITLE
Fix spacing in report.hbs

### DIFF
--- a/server/views/report.hbs
+++ b/server/views/report.hbs
@@ -4,7 +4,7 @@
     Report abuse.
   </h2>
   <p>
-    Report abuses, malware and phishing links to the email address below {{#if mail_enabled}}or use the form{{/if}}.
+    Report abuses, malware and phishing links to the email address below{{#if mail_enabled}} or use the form{{/if}}.
     We will review as soon as we can.
   </p>
   {{> report/email}}


### PR DESCRIPTION
<img width="1462" height="416" alt="image" src="https://github.com/user-attachments/assets/2812ab64-0683-4226-9383-e62a55c38103" />

i noticed that the space was placed wrong, aka ` .` 