### PR TITLE
Fix Edge browser detection in visit stats

### DIFF
--- a/server/queues/visit.js
+++ b/server/queues/visit.js
@@ -4,15 +4,7 @@ const URL = require("node:url");
 
 const { removeWww } = require("../utils");
 const query = require("../queries");
-
-const browsersList = ["IE", "Firefox", "Chrome", "Opera", "Safari", "Edge"];
 const osList = ["Windows", "Mac OS", "Linux", "Android", "iOS"];
-
-function filterInBrowser(agent) {
-  return function(item) {
-    return agent.family.toLowerCase().includes(item.toLocaleLowerCase());
-  }
-}
 
 function filterInOs(agent) {
   return function(item) {
@@ -20,16 +12,30 @@ function filterInOs(agent) {
   }
 }
 
+function detectBrowser(userAgent, agent) {
+  const source = (userAgent || "").toLowerCase();
+  const family = agent.family.toLowerCase();
+
+  // Check the more specific Chromium variants before generic Chrome/Safari.
+  if (/edg(e|a|ios)?\//i.test(source) || family.includes("edge")) return "Edge";
+  if (/opr\//i.test(source) || family.includes("opera")) return "Opera";
+  if (/firefox\/|fxios\//i.test(source) || family.includes("firefox")) return "Firefox";
+  if (/msie|trident\//i.test(source) || family.includes("ie")) return "IE";
+  if (/chrome\/|crios\//i.test(source) || family.includes("chrome")) return "Chrome";
+  if (/safari\//i.test(source) || family.includes("safari")) return "Safari";
+
+  return "Other";
+}
+
 module.exports = function({ data }) {
   const tasks = [];
   
   tasks.push(query.link.incrementVisit({ id:  data.link.id }));
-  
   // the following line is for backward compatibility
   // used to send the whole header to get the user agent
   const userAgent = data.userAgent || data.headers?.["user-agent"];
   const agent = useragent.parse(userAgent);
-  const [browser = "Other"] = browsersList.filter(filterInBrowser(agent));
+  const browser = detectBrowser(userAgent, agent);
   const [os = "Other"] = osList.filter(filterInOs(agent));
   const referrer =
   data.referrer && removeWww(URL.parse(data.referrer).hostname);


### PR DESCRIPTION
## Summary

This PR fixes browser detection in visit stats by checking Edge and Opera user agents before Chrome.

Previously, Chromium-based browsers such as Microsoft Edge could be detected as Chrome because their user agent includes the Chrome token. The detection order now handles Edge and Opera first, while Chrome, Safari, IE, and Other remain separate categories.

## Scope

- Updated browser detection logic in ``server/queues/visit.js``
- No database schema changes
- No stats aggregation changes