### PR TITLE
`CUSTOM_DOMAIN_USE_HTTPS` appears to be mistyped as a booleon value,

### DIFF
--- a/server/env.js
+++ b/server/env.js
@@ -53,7 +53,7 @@ const spec = {
   DISALLOW_LOGIN_FORM: bool({ default: false }),
   SERVER_IP_ADDRESS: str({ default: "" }),
   SERVER_CNAME_ADDRESS: str({ default: "" }),
-  CUSTOM_DOMAIN_USE_HTTPS: bool({ default: false }),
+  CUSTOM_DOMAIN_USE_HTTPS: str({ default: "" }),
   JWT_SECRET: str({ devDefault: "securekey" }),
   MAIL_ENABLED: bool({ default: false }),
   MAIL_HOST: str({ default: "" }),


### PR DESCRIPTION
changing it to a string and setting it to a domain gives https short links, whereas setting it to true doesn't do anything.

`function getShortURL` (line 75) in server/utils/utils.js logic doesn't make sense unless `CUSTOM_DOMAIN_USE_HTTPS` is a string value.