### PR TITLE
fix(express): update TRUST_PROXY configuration to accept hop count for reverse proxy trust

### DIFF
--- a/.example.env
+++ b/.example.env
@@ -40,8 +40,9 @@ LINK_CUSTOM_ALPHABET=abcdefghkmnpqrstuvwxyzABCDEFGHKLMNPQRSTUVWXYZ23456789
 
 # Optional - Tells the app that it's running behind a proxy server
 # and that it should get the IP address from that proxy server
-# if you're not using a proxy server then set this to false, otherwise users can override their IP address
-TRUST_PROXY=true
+# number of reverse proxy hops to trust for X-Forwarded-For
+# 0 (default) means don't trust it at all, and the client's direct connection IP is used 
+TRUST_PROXY=0
 
 # Optional - Redis host and port
 REDIS_ENABLED=false

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ You can use files for each of the variables by appending `_FILE` to the name of 
 | `DISALLOW_REGISTRATION` | Disable registration. Note that if `MAIL_ENABLED` is set to false, then the registration would still be disabled since it relies on emails to sign up users. | `true` | `false` |
 | `DISALLOW_LOGIN_FORM` | Disable login with email and password. Only makes sense if OIDC is enabled. | `false` | `true` |
 | `DISALLOW_ANONYMOUS_LINKS` | Disable anonymous link creation | `true` | `false` |
-| `TRUST_PROXY` | If the app is running behind a proxy server like NGINX or Cloudflare and that it should get the IP address from that proxy server. If you're not using a proxy server then set this to false, otherwise users can override their IP address. | `true` | `false` |
+| `TRUST_PROXY` | Number of reverse proxy hops to trust for reading the client IP from `X-Forwarded-For`. `0` means don't trust it at all. Never set this higher than the actual number of proxies, or clients can override their own IP and bypass rate limiting. `true`/`false` are also still accepted for backward compatibility (`true` trusts an unbounded chain). | `0` | `1` |
 | `DB_CLIENT` |  Which database client to use. Supported clients: `pg` or `pg-native` for Postgres, `mysql2` for MySQL or MariaDB, `sqlite3` and `better-sqlite3` for SQLite. NOTE: `pg-native` and `sqlite3` are not installed by default, use `npm` to install them before use. | `better-sqlite3` | `pg` |
 | `DB_FILENAME` |  File path for the SQLite database. Only if you use SQLite. | `db/data` | `/var/lib/data` |
 | `DB_HOST` | Database connection host. Only if you use Postgres or MySQL. | `localhost` | `your-db-host.com` |

--- a/server/env.js
+++ b/server/env.js
@@ -32,7 +32,7 @@ const spec = {
   DEFAULT_DOMAIN: str({ example: "kutt.to", default: "localhost:3000" }),
   LINK_LENGTH: num({ default: 6 }),
   LINK_CUSTOM_ALPHABET: str({ default: "abcdefghkmnpqrstuvwxyzABCDEFGHKLMNPQRSTUVWXYZ23456789" }),
-  TRUST_PROXY: bool({ default: true }),
+  TRUST_PROXY: str({ default: "0" }),
   DB_CLIENT: str({ choices: supportedDBClients, default: "better-sqlite3" }),
   DB_FILENAME: str({ default: "db/data" }),
   DB_HOST: str({ default: "localhost" }),

--- a/server/server.js
+++ b/server/server.js
@@ -30,10 +30,15 @@ require("./passport");
 // create express app
 const app = express();
 
-// this tells the express app that it's running behind a proxy server
-// and thus it should get the IP address from the proxy server
-if (env.TRUST_PROXY) {
+// TRUST_PROXY takes a hop count (example: 1 in the scenario with a single reverse proxy), which is the
+// only way to tell Express to trust just that many hops of X-Forwarded-For. 
+if (env.TRUST_PROXY === "true") {
   app.set("trust proxy", true);
+} else if (env.TRUST_PROXY !== "false") {
+  const trustProxyHops = Number(env.TRUST_PROXY);
+  if (trustProxyHops > 0) {
+    app.set("trust proxy", trustProxyHops);
+  }
 }
 
 app.use(helmet({ contentSecurityPolicy: false }));


### PR DESCRIPTION
As discussed on Telegram Chat and following thiese docs:

https://github.com/express-rate-limit/express-rate-limit/wiki/Troubleshooting-Proxy-Issues
and 
https://expressjs.com/en/guide/behind-proxies/

i propose a modification to avoid the IP overriding in case of TRUST_PROXY configuration

