### PR TITLE
Use identifier binding for column names in truncatedTimestamp

### DIFF
--- a/server/utils/knex.js
+++ b/server/utils/knex.js
@@ -11,7 +11,7 @@ function knexUtils(knex) {
           hour: "%Y-%m-%d %H:00:00",
           day: "%Y-%m-%d 00:00:00",
         };
-        return knex.raw(`strftime('${sqliteFormats[precision]}', ${columnName})`); // Default to 'hour'
+        return knex.raw(`strftime(?, ??)`, [sqliteFormats[precision], columnName]); // Default to 'hour'
       case "mssql":
         // For MSSQL, we can use FORMAT or CONVERT to truncate the timestamp
         const mssqlFormats = {
@@ -20,16 +20,16 @@ function knexUtils(knex) {
           hour: "yyyy-MM-dd HH:00:00",
           day: "yyyy-MM-dd 00:00:00",
         };
-        return knex.raw(`FORMAT(${columnName}, '${mssqlFormats[precision]}'`);
+        return knex.raw(`FORMAT(??, ?)`, [columnName, mssqlFormats[precision]]);
       case "pg":
       case "pgnative":
       case "cockroachdb":
         // PostgreSQL has the `date_trunc` function, which is ideal for this task
-        return knex.raw(`date_trunc(?, ${columnName} at time zone 'Z')`, [precision]);
+        return knex.raw(`date_trunc(?, ?? at time zone 'Z')`, [precision, columnName]);
       case "oracle":
       case "oracledb":
         // Oracle truncates dates using the `TRUNC` function
-        return knex.raw(`TRUNC(${columnName}, ?)`, [precision]);
+        return knex.raw(`TRUNC(??, ?)`, [columnName, precision]);
       case "mysql":
       case "mysql2":
         // MySQL can use the DATE_FORMAT function to truncate
@@ -39,7 +39,7 @@ function knexUtils(knex) {
           hour: "%Y-%m-%d %H:00:00",
           day: "%Y-%m-%d 00:00:00",
         };
-        return knex.raw(`DATE_FORMAT(${columnName}, '${mysqlFormats[precision]}')`);
+        return knex.raw(`DATE_FORMAT(??, ?)`, [columnName, mysqlFormats[precision]]);
       default:
         throw new Error(`${this.client.driverName} does not support timestamp truncation with precision`);
     }


### PR DESCRIPTION
## What

`truncatedTimestamp()` in `server/utils/knex.js` builds the raw SQL for date-truncation via template-literal string interpolation of `columnName` on all five database-driver branches, instead of knex's parameterized binding:

```js
return knex.raw(`strftime('${sqliteFormats[precision]}', ${columnName})`);
```

If `columnName` is ever influenced by request input, this is a classic SQL injection via the "it's just a column name" blind spot. It's the same shape the pg/oracle branches already half-avoid: they correctly use `?` for the `precision` value, but still interpolate `columnName` raw.

This PR switches all five branches to knex's `??` identifier binding for `columnName` (paired with `?` for the value), which knex escapes/quotes per-dialect. As a side effect, it also fixes a pre-existing bug in the mssql branch where the generated `FORMAT(...)` call was missing its closing parenthesis.

## Is this currently exploitable?

No — I checked. `truncatedTimestamp` has exactly one call site (`server/queries/visit.queries.js:23`), and both arguments are hardcoded literals (`"created_at"`, `"hour"`). No request-derived value reaches this function today, so I'm opening this as a normal PR rather than a security advisory.

The reason I think it's still worth fixing now: this sits in the visits/analytics query layer, which is a plausible place for a future "let the user pick the grouping granularity" feature to call this with a request-derived column name — at which point this would silently become a real, exploitable injection. Fixing the pattern now, while it's still just a shape rather than a live bug, seemed better than waiting.

## Verification

For each of the five dialects, I compared the SQL knex generates before/after against a fixed `columnName`/`precision` (`created_at`/`hour`, matching the current call site) to confirm it's unchanged in meaning:

| Dialect | Before | After |
|---|---|---|
| mysql | `DATE_FORMAT(created_at, '%Y-%m-%d %H:00:00')` | `` DATE_FORMAT(`created_at`, '%Y-%m-%d %H:00:00') `` |
| mssql | `FORMAT(created_at, 'yyyy-MM-dd HH:00:00'` *(missing `)`)* | `FORMAT([created_at], 'yyyy-MM-dd HH:00:00')` |
| pg | `date_trunc('hour', created_at at time zone 'Z')` | `date_trunc('hour', "created_at" at time zone 'Z')` |
| oracle | `TRUNC(created_at, 'hour')` | `TRUNC("created_at", 'hour')` |
| sqlite | `strftime('%Y-%m-%d %H:00:00', created_at)` | `strftime('%Y-%m-%d %H:00:00', "created_at")` |

And confirmed a crafted column name containing SQL metacharacters (e.g. `created_at"; DROP TABLE users; --`) is safely quoted as a single identifier by `??` rather than breaking out of the query, where the previous template-literal interpolation would have.

No behavior change for the existing call site; no new dependencies; no tests added since the repo doesn't have a test suite for this layer.