### PR TITLE
fix: move timestamp truncation logic to application startup, hardcoding both the column name and precision

### DIFF
--- a/server/queries/visit.queries.js
+++ b/server/queries/visit.queries.js
@@ -1,4 +1,4 @@
-const { isAfter, subDays, subHours, set, format } = require("date-fns");
+const { isAfter } = require("date-fns");
 
 const utils = require("../utils");
 const redis = require("../redis");
@@ -19,9 +19,7 @@ async function add(params) {
     // Create a subquery first that truncates the
     const subquery = trx("visits")
       .select("visits.*")
-      .select({
-        created_at_hours: utils.knexUtils(trx).truncatedTimestamp("created_at", "hour")
-      })
+      .select({ created_at_hours: utils.truncatedCreatedAtHour })
       .where({ link_id: data.link_id })
       .as("subquery");
 

--- a/server/utils/knex.js
+++ b/server/utils/knex.js
@@ -27,17 +27,17 @@ const precision = "hour";
 
 const truncatedCreatedAtHour =
   driverName === "sqlite3" || driverName === "better-sqlite3"
-    ? knex.raw(`strftime('${formats.sqlite3[precision]}', ${column})`)
+    ? knex.raw(`strftime(?, ??)`, [formats.sqlite3[precision], column])
     : driverName === "mssql"
-    ? knex.raw(`FORMAT(${column}, '${formats.mssql[precision]}')`)
+    ? knex.raw(`FORMAT(??, ?)`, [column, formats.mssql[precision]])
     : driverName === "pg" ||
         driverName === "pgnative" ||
         driverName === "cockroachdb"
-    ? knex.raw(`date_trunc(?, ${column} at time zone 'Z')`, [precision])
+    ? knex.raw(`date_trunc(?, ?? at time zone 'Z')`, [precision, column])
     : driverName === "oracle" || driverName === "oracledb"
-    ? knex.raw(`TRUNC(${column}, ?)`, [precision])
+    ? knex.raw(`TRUNC(??, ?)`, [column, precision])
     : driverName === "mysql" || driverName === "mysql2"
-    ? knex.raw(`DATE_FORMAT(${column}, '${formats.mysql[precision]}')`)
+    ? knex.raw(`DATE_FORMAT(??, ?)`, [column, formats.mysql[precision]])
     : (() => {
       throw new Error(
         `${driverName} does not support timestamp truncation with precision`,

--- a/server/utils/knex.js
+++ b/server/utils/knex.js
@@ -1,55 +1,47 @@
+const formats = {
+  sqlite3: {
+    // second: "%Y-%m-%d %H:%M:%S",
+    // minute: "%Y-%m-%d %H:%M:00",
+    hour: "%Y-%m-%d %H:00:00",
+    // day: "%Y-%m-%d 00:00:00",
+  },
+  mssql: {
+    // second: "yyyy-MM-dd HH:mm:ss",
+    // minute: "yyyy-MM-dd HH:mm:00",
+    hour: "yyyy-MM-dd HH:00:00",
+    // day: "yyyy-MM-dd 00:00:00",
+  },
+  mysql: {
+    // second: "%Y-%m-%d %H:%i:%s",
+    // minute: "%Y-%m-%d %H:%i:00",
+    hour: "%Y-%m-%d %H:00:00",
+    // day: "%Y-%m-%d 00:00:00",
+  },
+};
 
-function knexUtils(knex) {
-  function truncatedTimestamp(columnName, precision = "hour") {
-    switch (knex.client.driverName) {
-      case "sqlite3":
-      case "better-sqlite3":
-        // SQLite uses strftime for date truncation
-        const sqliteFormats = {
-          second: "%Y-%m-%d %H:%M:%S",
-          minute: "%Y-%m-%d %H:%M:00",
-          hour: "%Y-%m-%d %H:00:00",
-          day: "%Y-%m-%d 00:00:00",
-        };
-        return knex.raw(`strftime('${sqliteFormats[precision]}', ${columnName})`); // Default to 'hour'
-      case "mssql":
-        // For MSSQL, we can use FORMAT or CONVERT to truncate the timestamp
-        const mssqlFormats = {
-          second: "yyyy-MM-dd HH:mm:ss",
-          minute: "yyyy-MM-dd HH:mm:00",
-          hour: "yyyy-MM-dd HH:00:00",
-          day: "yyyy-MM-dd 00:00:00",
-        };
-        return knex.raw(`FORMAT(${columnName}, '${mssqlFormats[precision]}'`);
-      case "pg":
-      case "pgnative":
-      case "cockroachdb":
-        // PostgreSQL has the `date_trunc` function, which is ideal for this task
-        return knex.raw(`date_trunc(?, ${columnName} at time zone 'Z')`, [precision]);
-      case "oracle":
-      case "oracledb":
-        // Oracle truncates dates using the `TRUNC` function
-        return knex.raw(`TRUNC(${columnName}, ?)`, [precision]);
-      case "mysql":
-      case "mysql2":
-        // MySQL can use the DATE_FORMAT function to truncate
-        const mysqlFormats = {
-          second: "%Y-%m-%d %H:%i:%s",
-          minute: "%Y-%m-%d %H:%i:00",
-          hour: "%Y-%m-%d %H:00:00",
-          day: "%Y-%m-%d 00:00:00",
-        };
-        return knex.raw(`DATE_FORMAT(${columnName}, '${mysqlFormats[precision]}')`);
-      default:
-        throw new Error(`${this.client.driverName} does not support timestamp truncation with precision`);
-    }
-  }
+const knex = require("../knex");
+const { driverName } = knex.client;
 
-  return {
-    truncatedTimestamp
-  }
-}
+const column = "created_at";
+const precision = "hour";
 
-module.exports = {
-  knexUtils
-}
+const truncatedCreatedAtHour =
+  driverName === "sqlite3" || driverName === "better-sqlite3"
+    ? knex.raw(`strftime('${formats.sqlite3[precision]}', ${column})`)
+    : driverName === "mssql"
+    ? knex.raw(`FORMAT(${column}, '${formats.mssql[precision]}')`)
+    : driverName === "pg" ||
+        driverName === "pgnative" ||
+        driverName === "cockroachdb"
+    ? knex.raw(`date_trunc(?, ${column} at time zone 'Z')`, [precision])
+    : driverName === "oracle" || driverName === "oracledb"
+    ? knex.raw(`TRUNC(${column}, ?)`, [precision])
+    : driverName === "mysql" || driverName === "mysql2"
+    ? knex.raw(`DATE_FORMAT(${column}, '${formats.mysql[precision]}')`)
+    : (() => {
+      throw new Error(
+        `${driverName} does not support timestamp truncation with precision`,
+      );
+    })();
+
+module.exports = { truncatedCreatedAtHour };


### PR DESCRIPTION
If more flexibility is needed, more constants can be added to server/utils/knex.js.

Extraneous comments removed, second, minute, day values have been commented out since they are unused, but left for posterity / examples.